### PR TITLE
feat: refine MSA plots + per-sequence HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ reconstructed ancestor, and that sequence's statistics.
 derip2 -i tests/data/mintest.fa --per-seq-report -d results
 ```
 
+By default each sequence's mutation spectrum is measured against the deRIP-corrected
+consensus. Pass `--spectra-ref-index N` to compare against an alignment row instead
+(0-based; negatives count from the end). The chosen reference then has an empty
+self-comparison spectrum.
+
 Supply a GFF3 gene model with `--gff` (sequence ids must match the alignment;
 coordinates are auto-adjusted for gaps) to add a gene-annotation track to
 `--plot`, gene-effect panels (premature stops, non-synonymous changes,
@@ -316,6 +321,13 @@ Options:
                                   more sequences, the strongest strand-bias
                                   sequences are kept. Unset renders every
                                   sequence.
+  --spectra-ref-index INTEGER     Alignment row index (0-based; negatives
+                                  allowed) of a sequence to use as the
+                                  reference for the per-sequence report
+                                  mutation spectra, instead of the deRIP-
+                                  corrected consensus. The chosen reference
+                                  has an empty (self-comparison) spectrum.
+                                  Unset compares against the deRIP consensus.
   --gff TEXT                      GFF3 gene model. Sequence ids must match
                                   alignment record ids. Enables a gene-
                                   annotation track on --plot, gene-effect

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ derip2 -i tests/data/mintest.fa \
 
 ### With vizualization
 
-The `--plot` option will create a visualization of the alignment with RIP markup. The `--plot-rip-type` option can be used to specify the type of RIP events to be displayed in the alignment visualization `product`, `substrate`, or `both`.
+The `--plot` option will create a visualization of the alignment with RIP markup. The `--plot-rip-type` option can be used to specify the type of RIP events to be displayed in the alignment visualization `product`, `substrate`, or `both`. The `--plot-format` option selects the output file format: `svg` (default, scalable vector) or `png` (a fully rasterised, high-resolution image). For very wide alignments the SVG embeds its dense base grid as a raster that can blur at extreme zoom levels; choose `png` if you need a sharp image at any zoom.
 
 ```bash
 derip2 -i tests/data/mintest.fa \
@@ -264,6 +264,13 @@ Options:
                                   Specify the type of RIP events to be
                                   displayed in the alignment visualization.
                                   [default: both]
+  --plot-format [svg|png]         File format for the --plot alignment
+                                  visualization. "svg" is scalable vector
+                                  output (the dense base grid of wide
+                                  alignments is embedded as a raster and can
+                                  blur at extreme zoom); "png" is a fully
+                                  rasterised, high-resolution image that stays
+                                  sharp at any zoom level.  [default: svg]
   --plot-strand-bias              Create a diverging stacked-bar chart of per-
                                   column RIP strand bias.
   --strand-bias-scale [column|alignment|counts]

--- a/docs/cli-docs/deRIP_cmd_line.md
+++ b/docs/cli-docs/deRIP_cmd_line.md
@@ -30,7 +30,7 @@ derip2 -i tests/data/mintest.fa \
 
 ### With vizualization
 
-The `--plot` option will create a visualization of the alignment with RIP markup. The `--plot-rip-type` option can be used to specify the type of RIP events to be displayed in the alignment visualization `product`, `substrate`, or `both`.
+The `--plot` option will create a visualization of the alignment with RIP markup. The `--plot-rip-type` option can be used to specify the type of RIP events to be displayed in the alignment visualization `product`, `substrate`, or `both`. The `--plot-format` option selects the output file format: `svg` (default, scalable vector) or `png` (a fully rasterised, high-resolution image). For very wide alignments the SVG embeds its dense base grid as a raster that can blur at extreme zoom levels; choose `png` if you need a sharp image at any zoom.
 
 ```bash
 derip2 -i tests/data/mintest.fa \
@@ -198,6 +198,13 @@ annotation-track colours with a two-column `type<TAB>hex` file.
                                   Specify the type of RIP events to be
                                   displayed in the alignment visualization.
                                   [default: both]
+  --plot-format [svg|png]         File format for the --plot alignment
+                                  visualization. "svg" is scalable vector
+                                  output (the dense base grid of wide
+                                  alignments is embedded as a raster and can
+                                  blur at extreme zoom); "png" is a fully
+                                  rasterised, high-resolution image that stays
+                                  sharp at any zoom level.  [default: svg]
   --plot-strand-bias              Create a diverging stacked-bar chart of per-
                                   column RIP strand bias.
   --strand-bias-scale [column|alignment|counts]

--- a/docs/cli-docs/deRIP_cmd_line.md
+++ b/docs/cli-docs/deRIP_cmd_line.md
@@ -119,6 +119,19 @@ derip2 -i tests/data/sahana.fasta.gz \
   -d results
 ```
 
+By default every sequence's mutation spectrum is measured against the deRIP-corrected
+consensus. Use `--spectra-ref-index N` to compare against an alignment row instead
+(0-based; negative indices count from the end, so `-1` is the last sequence). The
+chosen reference then has an empty (self-comparison) spectrum, and the report prose
+names it.
+
+```bash
+derip2 -i tests/data/mintest.fa \
+  --per-seq-report \
+  --spectra-ref-index 0 \
+  -d results
+```
+
 ### Gene annotation and RIP effect reporting
 
 Supply a GFF3 gene model with `--gff`. Sequence ids in the GFF must match the
@@ -240,6 +253,13 @@ annotation-track colours with a two-column `type<TAB>hex` file.
                                   more sequences, the strongest strand-bias
                                   sequences are kept. Unset renders every
                                   sequence.
+  --spectra-ref-index INTEGER     Alignment row index (0-based; negatives
+                                  allowed) of a sequence to use as the
+                                  reference for the per-sequence report
+                                  mutation spectra, instead of the deRIP-
+                                  corrected consensus. The chosen reference
+                                  has an empty (self-comparison) spectrum.
+                                  Unset compares against the deRIP consensus.
   --gff TEXT                      GFF3 gene model. Sequence ids must match
                                   alignment record ids. Enables a gene-
                                   annotation track on --plot, gene-effect

--- a/src/derip2/annotation.py
+++ b/src/derip2/annotation.py
@@ -642,6 +642,33 @@ def translate_cds(
     return str(Seq(bases[:usable]).translate(table=genetic_code))
 
 
+def cds_display_id(gene: Gene) -> str:
+    """
+    Return the CDS ``ID`` attribute for display, falling back to the gene id.
+
+    :func:`parse_gff3` groups CDS rows by their ``Parent`` attribute, so
+    ``Gene.gene_id`` is the parent transcript rather than the CDS's own ``ID``.
+    All segments of one CDS share a single ``ID`` in GFF3, so the first segment's
+    ``feature_id`` identifies the CDS. This matters when one transcript owns
+    several distinct CDS records (isoforms): they must remain distinguishable in
+    the annotation-track tooltips.
+
+    Parameters
+    ----------
+    gene : Gene
+        The gene whose CDS ``ID`` is wanted.
+
+    Returns
+    -------
+    str
+        The first CDS segment's ``ID`` attribute, or ``gene.gene_id`` when the
+        CDS rows carried no ``ID``.
+    """
+    if gene.cds and gene.cds[0].feature_id:
+        return gene.cds[0].feature_id
+    return gene.gene_id
+
+
 def cds_alignment_columns(gene: Gene, ungapped_to_col: np.ndarray):
     """
     Project a gene's CDS onto its alignment columns, in transcription order.

--- a/src/derip2/app.py
+++ b/src/derip2/app.py
@@ -130,6 +130,18 @@ logger = logging.getLogger(__name__)
     show_default=True,
     help='Specify the type of RIP events to be displayed in the alignment visualization.',
 )
+@click.option(
+    '--plot-format',
+    type=click.Choice(['svg', 'png']),
+    default='svg',
+    show_default=True,
+    help=(
+        'File format for the --plot alignment visualization. "svg" is scalable '
+        'vector output (the dense base grid of wide alignments is embedded as a '
+        'raster and can blur at extreme zoom); "png" is a fully rasterised, '
+        'high-resolution image that stays sharp at any zoom level.'
+    ),
+)
 # Strand bias options
 @click.option(
     '--plot-strand-bias',
@@ -281,6 +293,7 @@ def main(
     prefix,
     plot,
     plot_rip_type,
+    plot_format,
     plot_strand_bias,
     strand_bias_scale,
     strand_bias_xaxis,
@@ -350,6 +363,10 @@ def main(
     plot_rip_type : str
         Specify the type of RIP events to be displayed in the alignment visualization.
         One of: 'both', 'product', or 'substrate'. Default: 'both'.
+    plot_format : str
+        File format for the --plot alignment visualization. One of: 'svg' or 'png'.
+        'svg' is scalable vector output; 'png' is a fully rasterised high-resolution
+        image that stays sharp at any zoom level. Default: 'svg'.
     plot_strand_bias : bool
         If True, create a diverging stacked-bar chart of per-column RIP strand
         bias. Default: False.
@@ -415,7 +432,7 @@ def main(
     if mask:
         out_path_aln = path.join(out_dir, f'{prefix}_masked_alignment.fasta')
     # Path for visualization - only used if plot is True
-    viz_path = path.join(out_dir, f'{prefix}_visualization.svg')
+    viz_path = path.join(out_dir, f'{prefix}_visualization.{plot_format}')
     strand_bias_path = path.join(out_dir, f'{prefix}_strand_bias.svg')
     stats_path = path.join(out_dir, f'{prefix}_stats.tsv')
     report_path = path.join(out_dir, f'{prefix}_report.html')

--- a/src/derip2/app.py
+++ b/src/derip2/app.py
@@ -243,6 +243,18 @@ logger = logging.getLogger(__name__)
         'kept. Unset renders every sequence.'
     ),
 )
+@click.option(
+    '--spectra-ref-index',
+    type=int,
+    default=None,
+    show_default=True,
+    help=(
+        'Alignment row index (0-based; negatives allowed) of a sequence to use '
+        'as the reference for the per-sequence report mutation spectra, instead '
+        'of the deRIP-corrected consensus. The chosen reference has an empty '
+        '(self-comparison) spectrum. Unset compares against the deRIP consensus.'
+    ),
+)
 # Gene annotation options
 @click.option(
     '--gff',
@@ -305,6 +317,7 @@ def main(
     html_report,
     per_seq_report,
     max_report_seqs,
+    spectra_ref_index,
     gff,
     genetic_code,
     annotation_colors,
@@ -398,6 +411,10 @@ def main(
     max_report_seqs : int or None
         Cap the number of sequence panels in the per-sequence report. If None,
         every sequence is rendered. Default: None.
+    spectra_ref_index : int or None
+        Alignment row index (0-based; negatives allowed) of a sequence to use as
+        the reference for the per-sequence report mutation spectra, instead of the
+        deRIP-corrected consensus. Default: None.
     gff : str or None
         Path to a GFF3 gene model. Enables the annotation track, gene-effect
         panels, and the SNP-effect summary. Default: None.
@@ -645,6 +662,14 @@ def main(
         )
 
     if per_seq_report:
+        if spectra_ref_index is not None:
+            n_aln = len(derip_obj.alignment)
+            if not -n_aln <= spectra_ref_index < n_aln:
+                raise click.BadParameter(
+                    f'{spectra_ref_index} is out of range for {n_aln} sequences '
+                    f'(valid: {-n_aln}..{n_aln - 1}).',
+                    param_hint='--spectra-ref-index',
+                )
         logger.info(
             f'Writing per-sequence HTML report to: \033[0m{per_seq_report_path}'
         )
@@ -655,6 +680,7 @@ def main(
             max_seqs=max_report_seqs,
             gff=gff,
             genetic_code=genetic_code,
+            spectra_ref_index=spectra_ref_index,
         )
 
 

--- a/src/derip2/persequence_report.py
+++ b/src/derip2/persequence_report.py
@@ -336,8 +336,8 @@ _PSR_STYLE = """
 }
 .legend .lg b { font-size: 1rem; line-height: 1; }
 
-/* Significant strand-asymmetry p-value. */
-.stat-card td.value.sig { font-weight: 700; }
+/* Significant strand-asymmetry p-value (< 0.05): coloured green, not bold. */
+.stat-card td.value.sig { color: #007a3d; }
 
 /* Wide figures (alignment row, strand bias) keep their intrinsic width and
    scroll horizontally rather than being squashed to page width, so bars stay
@@ -473,36 +473,58 @@ _PSR_STYLE = """
 }
 .psr-copy:hover { border-color: var(--muted); }
 
-/* Overview all-sequence summary statistics table (sortable). */
-.stats-scroll { overflow-x: auto; margin: .2rem 0 1rem; }
+/* Overview all-sequence summary statistics table (sortable). The box scrolls in
+   both axes with a capped height; the two header rows stay pinned to the top and
+   the sequence-name column stays pinned to the left (via position: sticky). The
+   --h1 offset is the height of the first (group) header row, so the second header
+   row sits directly below it. */
+.stats-scroll {
+  --h1: 1.9rem;
+  overflow: auto; max-height: 70vh; margin: .2rem 0 1rem;
+}
 .psr-stats {
-  border-collapse: collapse; font-size: 13px; white-space: nowrap;
-  font-variant-numeric: tabular-nums;
+  border-collapse: separate; border-spacing: 0; font-size: 13px;
+  white-space: nowrap; font-variant-numeric: tabular-nums;
 }
 .psr-stats th, .psr-stats td {
   padding: .35rem .6rem; border-bottom: 1px solid var(--rule); text-align: right;
 }
 .psr-stats thead th {
-  background: var(--surface); position: sticky; top: 0;
+  background: var(--surface); position: sticky; z-index: 3;
   border-bottom: 1px solid var(--rule);
 }
+.psr-stats thead tr:first-child th { top: 0; height: var(--h1); }
+.psr-stats thead tr:nth-child(2) th { top: var(--h1); }
 .psr-stats thead th.grp {
   text-align: center; font-weight: 600;
   border-left: 1px solid var(--rule); border-right: 1px solid var(--rule);
 }
-.psr-stats th[scope="row"] { text-align: left; font-weight: 600; }
+/* Sticky first column (sequence names) — header corner sits above everything. */
+.psr-stats th[scope="row"] {
+  text-align: left; font-weight: 600; position: sticky; left: 0; z-index: 2;
+  background: var(--page); border-right: 1px solid var(--rule);
+}
+.psr-stats thead th.corner { left: 0; z-index: 4; }
+.psr-stats tbody tr:hover th[scope="row"] { background: var(--surface); }
 .psr-stats th.sortable { cursor: pointer; user-select: none; }
 .psr-stats th.sortable:hover { color: var(--ink); }
 .psr-stats th.sortable::after { content: ''; margin-left: .3rem; color: var(--muted); }
 .psr-stats th.sortable[data-dir="asc"]::after { content: '▲'; }
 .psr-stats th.sortable[data-dir="desc"]::after { content: '▼'; }
+.psr-stats .seq-link {
+  color: inherit; text-decoration: underline; text-decoration-style: dotted;
+  text-underline-offset: 2px; cursor: pointer;
+}
+.psr-stats .seq-link:hover { text-decoration-style: solid; }
 .psr-stats td.value.muted { color: var(--muted); }
 .psr-stats td.value.pos { color: #007a3d; }
 .psr-stats td.value.neg { color: #b4292a; }
-.psr-stats tbody tr:hover { background: var(--surface); }
+.psr-stats tbody tr:hover td { background: var(--surface); }
 .psr-stats tr.consensus-row th[scope="row"],
 .psr-stats tr.consensus-row td { font-weight: 600; }
-.psr-stats tr.consensus-row { border-top: 2px solid var(--muted); }
+.psr-stats tr.consensus-row td, .psr-stats tr.consensus-row th[scope="row"] {
+  border-top: 2px solid var(--muted);
+}
 """
 
 # The click-to-view FASTA modal, injected once per report. Populated and shown by
@@ -812,7 +834,35 @@ _PSR_SCRIPT = """
     });
   }
 
+  // Sequence names in the overview stats table jump to that sequence's page.
+  // Scroll position is preserved (as with arrow-key navigation); the sticky nav
+  // and panel header keep the reader oriented.
+  document.addEventListener('click', function (e) {
+    var link = e.target.closest && e.target.closest('[data-goto]');
+    if (!link) { return; }
+    e.preventDefault();
+    show(parseInt(link.getAttribute('data-goto'), 10));
+  });
+
+  // Land on the overview with the whole MSA figure visible: shrink the shared
+  // zoom just enough to fit the alignment figure in its scroll box (never zoom in
+  // past 100%). Widths are then applied by applyZoom below.
+  function fitOverview() {
+    var box = document.querySelector(
+      '.seq-panel[data-index="overview"] .aln-scroll');
+    if (!box) { return; }
+    var svg = box.querySelector('svg');
+    if (!svg) { return; }
+    var base = svgBasePx(svg);
+    var avail = box.clientWidth - 12;   // minus the box padding
+    if (base > 0 && avail > 0 && avail < base) {
+      zoom = Math.max(0.25, avail / base);
+    }
+  }
+
   show(0);
+  fitOverview();
+  applyZoom();
 })();
 """
 
@@ -1190,7 +1240,7 @@ def _overview_svg(derip, cds_tracks, fasta_data=None):
     return svg
 
 
-def _overview_stats_table_html(df, derip):
+def _overview_stats_table_html(df, derip, row_to_panel=None):
     """
     Build the sortable all-sequence statistics table for the overview page.
 
@@ -1199,7 +1249,9 @@ def _overview_stats_table_html(df, derip):
     (:data:`_STAT_SECTIONS`). The consensus is the RIP-free reconstructed
     ancestor, so its RIP-event and strand-bias (RSI) columns are not applicable
     and render as an en-dash; only composition (GC) and the Composite RIP Index
-    (CRI/PI/SI) are computed for it. Every column is click-to-sort in the browser
+    (CRI/PI/SI) are computed for it. A positive-RIP CRI (> 1) is coloured green
+    and a significant strand-asymmetry p-value (< 0.05) is coloured green, as on
+    the per-sequence cards. Every column is click-to-sort in the browser
     (numeric-aware; en-dash cells sort last).
 
     Parameters
@@ -1208,6 +1260,11 @@ def _overview_stats_table_html(df, derip):
         The per-sequence statistics (:meth:`derip2.derip.DeRIP.summarize_stats`).
     derip : derip2.derip.DeRIP
         The analysed DeRIP object (for the consensus row's GC and CRI).
+    row_to_panel : dict of int to int, optional
+        Maps an alignment row index to the 1-based panel position of that
+        sequence's per-sequence page. Sequences present here get their name
+        linked to their page; sequences dropped by ``--max-report-seqs`` (absent
+        from the map) render as plain text.
 
     Returns
     -------
@@ -1215,6 +1272,8 @@ def _overview_stats_table_html(df, derip):
         The ``<table class="psr-stats">`` markup (with its wrapping scroll div).
     """
     from Bio.SeqUtils import gc_fraction
+
+    row_to_panel = row_to_panel or {}
 
     # Flatten the grouped layout into one ordered column list plus the group
     # spans that head it. 'RIP_total' is derived (fwd + rev), as on the cards.
@@ -1235,13 +1294,13 @@ def _overview_stats_table_html(df, derip):
     )
     thead = (
         '<thead>'
-        '<tr><th class="sortable" data-ci="0" rowspan="2">Sequence</th>'
+        '<tr><th class="sortable corner" data-ci="0" rowspan="2">Sequence</th>'
         f'{grp_ths}</tr>'
         f'<tr>{col_ths}</tr>'
         '</thead>'
     )
 
-    def _row_html(label, values, is_consensus=False):
+    def _row_html(label, values, is_consensus=False, panel=None):
         """
         Build one table row: a leading label cell then a cell per flat column.
 
@@ -1253,19 +1312,31 @@ def _overview_stats_table_html(df, derip):
             Column-name to value; missing columns render as an en-dash.
         is_consensus : bool, optional
             Whether this is the deRIP-consensus row (adds a marker class).
+        panel : int, optional
+            1-based panel position of this sequence's per-sequence page; when
+            given the name links to it. ``None`` leaves the name as plain text.
 
         Returns
         -------
         str
             The ``<tr>`` element for this row.
         """
-        cells = [f'<th scope="row">{escape(str(label))}</th>']
+        name = escape(str(label))
+        if panel is not None:
+            name = f'<a class="seq-link" href="#" data-goto="{panel}">{name}</a>'
+        cells = [f'<th scope="row">{name}</th>']
         for col, _lab in flat:
             value = values.get(col)
             if col == 'RIP_total' and value is not None:
                 text, css = str(int(value)), ''
             else:
                 text, css = _format_cell(col, value)
+            # Green flags, matching the per-sequence cards: a positive-RIP CRI
+            # (> 1) and a significant strand-asymmetry p-value (< 0.05).
+            if col == 'CRI' and isinstance(value, (int, float)) and value > 1:
+                css = 'pos'
+            elif col == 'pvalue' and isinstance(value, (int, float)) and value < 0.05:
+                css = 'pos'
             cls = f' class="value {css}"'.rstrip() if css else ' class="value"'
             cells.append(f'<td{cls}>{text}</td>')
         tr_cls = ' class="consensus-row"' if is_consensus else ''
@@ -1276,7 +1347,7 @@ def _overview_stats_table_html(df, derip):
         row = df.iloc[i]
         values = {col: row[col] for col, _lab in flat if col in row.index}
         values['RIP_total'] = int(row['RIP_fwd']) + int(row['RIP_rev'])
-        rows.append(_row_html(row['ID'], values))
+        rows.append(_row_html(row['ID'], values, panel=row_to_panel.get(i)))
 
     # The deRIP consensus row: GC + CRI/PI/SI only; RIP/RSI columns stay None so
     # _format_cell renders them as an en-dash (not applicable to the ancestor).
@@ -1297,7 +1368,42 @@ def _overview_stats_table_html(df, derip):
     )
 
 
-def _overview_html(derip, cds_tracks, fasta_data=None, downloads=(), df=None):
+def _overview_spectrum_svg(derip):
+    """
+    Render the pooled SBS-96 spectrum (all sequences vs the deRIP reference).
+
+    Every alignment cell that differs from the deRIP-corrected reference is one
+    substitution event; pooling all sequences into a single sample gives the
+    alignment-wide mutation spectrum (dominated by the C→T / G→A RIP signature).
+    Rendered like the per-sequence spectra (wide, bare, fixed geometry) so it
+    scrolls on its own and reads consistently.
+
+    Parameters
+    ----------
+    derip : derip2.derip.DeRIP
+        The analysed DeRIP object.
+
+    Returns
+    -------
+    str
+        The inline ``<svg>`` fragment (id-prefixed), or ``''`` if no substitution
+        events were observed.
+    """
+    import matplotlib.pyplot as plt
+
+    from derip2.plotting.spectra import plot_sbs96
+
+    spectra_all = derip.calculate_spectra(partition_by='none')
+    fig = plot_sbs96(spectra_all, sample=0, width=11.0, bare=True)
+    _fix_spectrum_axes(fig)
+    svg = _figure_to_svg(fig, 'ovwsbs-', tight=False)
+    plt.close(fig)
+    return svg
+
+
+def _overview_html(
+    derip, cds_tracks, fasta_data=None, downloads=(), df=None, row_to_panel=None
+):
     """
     Build the report's front (overview) page: the full alignment + consensus.
 
@@ -1315,6 +1421,9 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=(), df=None):
     df : pandas.DataFrame, optional
         The per-sequence statistics; when given, a sortable all-sequence stats
         table (plus the deRIP consensus row) is added below the alignment figure.
+    row_to_panel : dict of int to int, optional
+        Row-index to panel-position map so the stats table can link each sequence
+        name to its per-sequence page (see :func:`_overview_stats_table_html`).
 
     Returns
     -------
@@ -1322,6 +1431,7 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=(), df=None):
         The overview ``<section class="seq-panel">`` (first page of the deck).
     """
     svg = _overview_svg(derip, cds_tracks, fasta_data)
+    spectrum_svg = _overview_spectrum_svg(derip)
     n_total = len(derip.alignment)
     n_cols = derip.alignment.get_alignment_length()
 
@@ -1340,15 +1450,23 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=(), df=None):
         )
     toolbar = f'<div class="psr-toolbar">{"".join(tools)}</div>' if tools else ''
 
+    spectrum_section = (
+        '<h3>Mutation spectrum</h3>'
+        '<p class="desc">SBS-96 trinucleotide spectrum of every substitution '
+        'across all sequences relative to the deRIP-corrected reference. The '
+        'C&rarr;T / G&rarr;A dominance is the RIP signature.</p>'
+        f'<div class="spectrum-scroll">{spectrum_svg}</div>'
+    )
+
     stats_section = ''
     if df is not None:
         stats_section = (
             '<h3>Summary statistics</h3>'
             '<p class="desc">Per-sequence statistics for every sequence plus the '
             'deRIP-corrected consensus (its RIP-event and strand-bias columns are '
-            'not applicable and shown as &ndash;). Click any column heading to '
-            'sort.</p>'
-            f'{_overview_stats_table_html(df, derip)}'
+            'not applicable and shown as &ndash;). Click a sequence name to open '
+            'its page, or a column heading to sort.</p>'
+            f'{_overview_stats_table_html(df, derip, row_to_panel)}'
         )
 
     return (
@@ -1362,6 +1480,7 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=(), df=None):
         'annotation to view its FASTA.</p>'
         f'{toolbar}'
         f'<div class="aln-scroll">{svg}</div>'
+        f'{spectrum_section}'
         f'{stats_section}'
         '</section>'
     )
@@ -1599,9 +1718,17 @@ def write_per_sequence_report(
 
     indices, truncated = _select_rows(df, max_seqs)
 
+    # Map each rendered sequence's alignment-row index to its 1-based panel
+    # position (panel 0 is the overview), so the overview stats table can link a
+    # sequence name to its page. Sequences dropped by --max-report-seqs are absent
+    # and left unlinked.
+    row_to_panel = {row_index: pos for pos, row_index in enumerate(indices, start=1)}
+
     # The front (overview) page — the full alignment + deRIP consensus — followed
     # by one panel per sequence.
-    panels = [_overview_html(derip, overview_track, fasta_data, downloads, df)]
+    panels = [
+        _overview_html(derip, overview_track, fasta_data, downloads, df, row_to_panel)
+    ]
     panels += [
         _panel_html(
             derip,

--- a/src/derip2/persequence_report.py
+++ b/src/derip2/persequence_report.py
@@ -180,6 +180,26 @@ def _data_uri(text):
     return f'data:text/plain;charset=utf-8;base64,{b64}'
 
 
+def _reference_phrase(label):
+    """
+    Describe the mutation-spectrum reference for the report prose.
+
+    Parameters
+    ----------
+    label : str or None
+        The reference sequence's id when a specific alignment row was chosen, or
+        ``None`` to use the default deRIP-corrected consensus.
+
+    Returns
+    -------
+    str
+        An HTML phrase naming the reference (the label is code-formatted).
+    """
+    if label is None:
+        return 'the reconstructed deRIP&rsquo;d ancestor'
+    return f'reference sequence <code>{escape(str(label))}</code>'
+
+
 def _zoom_control():
     """
     Build the (class-based) zoom control for a panel header.
@@ -986,6 +1006,8 @@ def _panel_html(
     deripd_aa,
     cds_gene_cols=(),
     genetic_code=1,
+    spectra_ref_index=None,
+    spectra_ref_label=None,
 ):
     """
     Build the HTML for one sequence's panel.
@@ -1016,6 +1038,13 @@ def _panel_html(
         per-subject CDS track. Empty when no GFF was supplied.
     genetic_code : int, optional
         NCBI translation table for the projected stop-codon calls (default: 1).
+    spectra_ref_index : int, optional
+        Alignment row index of the sequence used as the spectra reference; when
+        it equals ``row_index`` this panel's spectrum is a self-comparison
+        (empty by definition) and a note is shown. ``None`` = deRIP consensus.
+    spectra_ref_label : str, optional
+        The reference sequence's id, used in the spectrum prose. ``None`` = the
+        default deRIP-corrected consensus.
 
     Returns
     -------
@@ -1112,6 +1141,15 @@ def _panel_html(
     ds_svg = _figure_to_svg(ds, f's{row_index}ds-', tight=False)
     plt.close(ds)
 
+    # When this sequence is itself the chosen spectra reference, its spectrum is a
+    # self-comparison and therefore empty by construction; flag that up front.
+    ref_note = ''
+    if spectra_ref_index is not None and row_index == spectra_ref_index:
+        ref_note = (
+            '<p class="note">This sequence is the chosen spectra reference, so its '
+            'spectrum is empty (every base matches itself).</p>'
+        )
+
     # Gene-effect panel: only shown when a GFF annotated this sequence.
     effect_html = ''
     if seq_id in genes_by_seqid:
@@ -1160,10 +1198,11 @@ def _panel_html(
         'converting C to T, so a low bar is consistent with heavy RIP.</p>'
         f'<div class="figure-fixed">{gc_svg}</div>'
         '<h3>Mutation spectrum (SBS-96)</h3>'
+        f'{ref_note}'
         '<p class="desc">The single-base-substitution spectrum of this sequence '
-        'measured against the reconstructed ancestor, in trinucleotide context '
-        '(5′-N[R&gt;A]N-3′). RIP shows up as a C&gt;T peak in CpA context. Scroll '
-        'horizontally if the 96 channels do not fit.</p>'
+        f'measured against {_reference_phrase(spectra_ref_label)}, in '
+        'trinucleotide context (5′-N[R&gt;A]N-3′). RIP shows up as a C&gt;T peak '
+        'in CpA context. Scroll horizontally if the 96 channels do not fit.</p>'
         f'<div class="spectrum-scroll">{sbs_svg}</div>'
         '<h3>Mutation spectrum (downstream context)</h3>'
         '<p class="desc">The same substitutions classified by the mutated base '
@@ -1370,20 +1409,23 @@ def _overview_stats_table_html(df, derip, row_to_panel=None):
     )
 
 
-def _overview_spectrum_svg(derip):
+def _overview_spectrum_svg(derip, ancestor=None):
     """
-    Render the pooled SBS-96 spectrum (all sequences vs the deRIP reference).
+    Render the pooled SBS-96 spectrum (all sequences vs the spectra reference).
 
-    Every alignment cell that differs from the deRIP-corrected reference is one
-    substitution event; pooling all sequences into a single sample gives the
-    alignment-wide mutation spectrum (dominated by the C→T / G→A RIP signature).
-    Rendered like the per-sequence spectra (wide, bare, fixed geometry) so it
-    scrolls on its own and reads consistently.
+    Every alignment cell that differs from the reference is one substitution
+    event; pooling all sequences into a single sample gives the alignment-wide
+    mutation spectrum (dominated by the C→T / G→A RIP signature). Rendered like
+    the per-sequence spectra (wide, bare, fixed geometry) so it scrolls on its own
+    and reads consistently.
 
     Parameters
     ----------
     derip : derip2.derip.DeRIP
         The analysed DeRIP object.
+    ancestor : str or None, optional
+        Reference sequence (one base per alignment column) to compare every
+        sequence against. ``None`` (default) uses the deRIP-corrected consensus.
 
     Returns
     -------
@@ -1395,7 +1437,7 @@ def _overview_spectrum_svg(derip):
 
     from derip2.plotting.spectra import plot_sbs96
 
-    spectra_all = derip.calculate_spectra(partition_by='none')
+    spectra_all = derip.calculate_spectra(partition_by='none', ancestor=ancestor)
     fig = plot_sbs96(spectra_all, sample=0, width=11.0, bare=True)
     _fix_spectrum_axes(fig)
     svg = _figure_to_svg(fig, 'ovwsbs-', tight=False)
@@ -1404,7 +1446,14 @@ def _overview_spectrum_svg(derip):
 
 
 def _overview_html(
-    derip, cds_tracks, fasta_data=None, downloads=(), df=None, row_to_panel=None
+    derip,
+    cds_tracks,
+    fasta_data=None,
+    downloads=(),
+    df=None,
+    row_to_panel=None,
+    spectra_ref_ancestor=None,
+    spectra_ref_label=None,
 ):
     """
     Build the report's front (overview) page: the full alignment + consensus.
@@ -1426,6 +1475,12 @@ def _overview_html(
     row_to_panel : dict of int to int, optional
         Row-index to panel-position map so the stats table can link each sequence
         name to its per-sequence page (see :func:`_overview_stats_table_html`).
+    spectra_ref_ancestor : str or None, optional
+        Reference sequence for the pooled spectrum (one base per column). ``None``
+        uses the deRIP consensus.
+    spectra_ref_label : str or None, optional
+        The reference sequence's id, used in the spectrum prose. ``None`` = the
+        deRIP-corrected consensus.
 
     Returns
     -------
@@ -1433,7 +1488,7 @@ def _overview_html(
         The overview ``<section class="seq-panel">`` (first page of the deck).
     """
     svg = _overview_svg(derip, cds_tracks, fasta_data)
-    spectrum_svg = _overview_spectrum_svg(derip)
+    spectrum_svg = _overview_spectrum_svg(derip, spectra_ref_ancestor)
     n_total = len(derip.alignment)
     n_cols = derip.alignment.get_alignment_length()
 
@@ -1455,8 +1510,8 @@ def _overview_html(
     spectrum_section = (
         '<h3>Mutation spectrum</h3>'
         '<p class="desc">SBS-96 trinucleotide spectrum of every substitution '
-        'across all sequences relative to the deRIP-corrected reference. The '
-        'C&rarr;T / G&rarr;A dominance is the RIP signature.</p>'
+        f'across all sequences relative to {_reference_phrase(spectra_ref_label)}. '
+        'The C&rarr;T / G&rarr;A dominance is the RIP signature.</p>'
         f'<div class="spectrum-scroll">{spectrum_svg}</div>'
     )
 
@@ -1562,6 +1617,7 @@ def write_per_sequence_report(
     max_seqs=None,
     gff=None,
     genetic_code=1,
+    spectra_ref_index=None,
 ):
     """
     Write a single-file, arrow-key-navigable per-sequence HTML report.
@@ -1587,11 +1643,22 @@ def write_per_sequence_report(
         gains a gene-effect table and the deRIP-restored protein.
     genetic_code : int, optional
         NCBI translation table for the effect prediction (default: 1).
+    spectra_ref_index : int, optional
+        Alignment row index of a sequence to use as the reference for the
+        mutation spectra (per-sequence and the pooled overview), instead of the
+        default deRIP-corrected consensus. Supports negative indexing. The
+        reference sequence's own panel then shows an empty (self-comparison)
+        spectrum.
 
     Returns
     -------
     str
         The path written.
+
+    Raises
+    ------
+    ValueError
+        If ``spectra_ref_index`` is out of range for the alignment.
 
     Notes
     -----
@@ -1606,11 +1673,39 @@ def write_per_sequence_report(
     logger.info(f'Building per-sequence report for {n_seqs} sequences...')
 
     df = derip.summarize_stats(ambiguous=ambiguous)
-    # One sample column per sequence, measured against the reconstructed
-    # ancestor, in each context. Computed once and reused across every panel.
-    logger.info('Computing per-sequence mutation spectra...')
-    spectra = derip.calculate_spectra(partition_by='row')
-    downstream = derip.calculate_spectra(partition_by='row', context='downstream')
+
+    # Resolve the mutation-spectra reference. By default every sequence is
+    # compared to the deRIP-corrected consensus; a user may instead pick an
+    # alignment row (its gapped sequence, one base per column) as the reference.
+    spectra_ref_ancestor = None
+    spectra_ref_label = None
+    if spectra_ref_index is not None:
+        if not -n_seqs <= spectra_ref_index < n_seqs:
+            raise ValueError(
+                f'spectra_ref_index {spectra_ref_index} is out of range for an '
+                f'alignment of {n_seqs} sequences (valid: '
+                f'{-n_seqs}..{n_seqs - 1}).'
+            )
+        # Normalise a negative index so row_index comparisons in the panels match.
+        spectra_ref_index %= n_seqs
+        ref_record = derip.alignment[spectra_ref_index]
+        spectra_ref_ancestor = str(ref_record.seq)
+        spectra_ref_label = ref_record.id
+        logger.info(
+            f'Computing mutation spectra against reference row '
+            f'{spectra_ref_index} ({spectra_ref_label}) instead of the deRIP '
+            f'consensus...'
+        )
+    else:
+        logger.info('Computing per-sequence mutation spectra...')
+
+    # One sample column per sequence, measured against the chosen reference (the
+    # reconstructed ancestor by default), in each context. Computed once and
+    # reused across every panel.
+    spectra = derip.calculate_spectra(partition_by='row', ancestor=spectra_ref_ancestor)
+    downstream = derip.calculate_spectra(
+        partition_by='row', ancestor=spectra_ref_ancestor, context='downstream'
+    )
 
     # FASTA payloads for the overview downloads + click-to-view popups. The deRIP
     # sequence is always available; CDS records are added when a GFF is supplied.
@@ -1739,7 +1834,16 @@ def write_per_sequence_report(
     # (slow on many rows/columns), so it gets its own message.
     logger.info('Rendering overview page (full alignment + summary)...')
     panels = [
-        _overview_html(derip, overview_track, fasta_data, downloads, df, row_to_panel)
+        _overview_html(
+            derip,
+            overview_track,
+            fasta_data,
+            downloads,
+            df,
+            row_to_panel,
+            spectra_ref_ancestor,
+            spectra_ref_label,
+        )
     ]
     # The per-sequence panels dominate the runtime on large alignments (each is
     # ~6 matplotlib figures rendered to inline SVG), so show a progress bar.
@@ -1757,6 +1861,8 @@ def write_per_sequence_report(
             deripd_aa,
             cds_gene_cols,
             genetic_code,
+            spectra_ref_index,
+            spectra_ref_label,
         )
         for panel_number, row_index in tqdm(
             enumerate(indices, start=1),

--- a/src/derip2/persequence_report.py
+++ b/src/derip2/persequence_report.py
@@ -472,6 +472,37 @@ _PSR_STYLE = """
   border-radius: 6px;
 }
 .psr-copy:hover { border-color: var(--muted); }
+
+/* Overview all-sequence summary statistics table (sortable). */
+.stats-scroll { overflow-x: auto; margin: .2rem 0 1rem; }
+.psr-stats {
+  border-collapse: collapse; font-size: 13px; white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.psr-stats th, .psr-stats td {
+  padding: .35rem .6rem; border-bottom: 1px solid var(--rule); text-align: right;
+}
+.psr-stats thead th {
+  background: var(--surface); position: sticky; top: 0;
+  border-bottom: 1px solid var(--rule);
+}
+.psr-stats thead th.grp {
+  text-align: center; font-weight: 600;
+  border-left: 1px solid var(--rule); border-right: 1px solid var(--rule);
+}
+.psr-stats th[scope="row"] { text-align: left; font-weight: 600; }
+.psr-stats th.sortable { cursor: pointer; user-select: none; }
+.psr-stats th.sortable:hover { color: var(--ink); }
+.psr-stats th.sortable::after { content: ''; margin-left: .3rem; color: var(--muted); }
+.psr-stats th.sortable[data-dir="asc"]::after { content: '▲'; }
+.psr-stats th.sortable[data-dir="desc"]::after { content: '▼'; }
+.psr-stats td.value.muted { color: var(--muted); }
+.psr-stats td.value.pos { color: #007a3d; }
+.psr-stats td.value.neg { color: #b4292a; }
+.psr-stats tbody tr:hover { background: var(--surface); }
+.psr-stats tr.consensus-row th[scope="row"],
+.psr-stats tr.consensus-row td { font-weight: 600; }
+.psr-stats tr.consensus-row { border-top: 2px solid var(--muted); }
 """
 
 # The click-to-view FASTA modal, injected once per report. Populated and shown by
@@ -738,6 +769,46 @@ _PSR_SCRIPT = """
     });
     document.addEventListener('keydown', function (e) {
       if (e.key === 'Escape' && !modal.hasAttribute('hidden')) { closeFastaModal(); }
+    });
+  }
+
+  // Sortable overview stats table. Each sortable header carries its column index
+  // (data-ci); a click sorts the tbody rows by that column. Cells are compared
+  // numerically when both parse as numbers (a leading '+' is stripped), otherwise
+  // as text; en-dash / empty cells (not-applicable stats) always sort last.
+  function cellVal(td) {
+    var t = (td.textContent || '').trim();
+    if (t === '' || t === '\\u2013' || t === '\\u2014') { return { n: null, s: '' }; }
+    var n = parseFloat(t.replace('+', ''));
+    return isNaN(n) ? { n: null, s: t } : { n: n, s: t };
+  }
+  var statsTable = document.querySelector('table.psr-stats');
+  if (statsTable && statsTable.tBodies.length) {
+    var statsBody = statsTable.tBodies[0];
+    var sortDir = null, sortCi = null;
+    Array.prototype.slice.call(
+      statsTable.querySelectorAll('th.sortable')).forEach(function (th) {
+      th.addEventListener('click', function () {
+        var ci = parseInt(th.getAttribute('data-ci'), 10);
+        var asc = !(sortCi === ci && sortDir === 'asc');
+        sortCi = ci; sortDir = asc ? 'asc' : 'desc';
+        var rows = Array.prototype.slice.call(statsBody.rows);
+        rows.sort(function (a, b) {
+          var x = cellVal(a.cells[ci]), y = cellVal(b.cells[ci]);
+          if (x.n === null && y.n === null) {
+            return asc ? x.s.localeCompare(y.s) : y.s.localeCompare(x.s);
+          }
+          if (x.n === null) { return 1; }   // not-applicable sorts last
+          if (y.n === null) { return -1; }
+          return asc ? x.n - y.n : y.n - x.n;
+        });
+        rows.forEach(function (r) { statsBody.appendChild(r); });
+        Array.prototype.slice.call(
+          statsTable.querySelectorAll('th.sortable')).forEach(function (h) {
+          h.removeAttribute('data-dir');
+        });
+        th.setAttribute('data-dir', asc ? 'asc' : 'desc');
+      });
     });
   }
 
@@ -1119,7 +1190,114 @@ def _overview_svg(derip, cds_tracks, fasta_data=None):
     return svg
 
 
-def _overview_html(derip, cds_tracks, fasta_data=None, downloads=()):
+def _overview_stats_table_html(df, derip):
+    """
+    Build the sortable all-sequence statistics table for the overview page.
+
+    One row per input sequence plus a final row for the deRIP-corrected
+    consensus, with the columns grouped exactly as the per-sequence stat cards
+    (:data:`_STAT_SECTIONS`). The consensus is the RIP-free reconstructed
+    ancestor, so its RIP-event and strand-bias (RSI) columns are not applicable
+    and render as an en-dash; only composition (GC) and the Composite RIP Index
+    (CRI/PI/SI) are computed for it. Every column is click-to-sort in the browser
+    (numeric-aware; en-dash cells sort last).
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The per-sequence statistics (:meth:`derip2.derip.DeRIP.summarize_stats`).
+    derip : derip2.derip.DeRIP
+        The analysed DeRIP object (for the consensus row's GC and CRI).
+
+    Returns
+    -------
+    str
+        The ``<table class="psr-stats">`` markup (with its wrapping scroll div).
+    """
+    from Bio.SeqUtils import gc_fraction
+
+    # Flatten the grouped layout into one ordered column list plus the group
+    # spans that head it. 'RIP_total' is derived (fwd + rev), as on the cards.
+    flat = []  # (column, label)
+    group_spans = []  # (group title, colspan)
+    for title, _desc, cols in _STAT_SECTIONS:
+        group_spans.append((title, len(cols)))
+        flat.extend(cols)
+
+    # Two-row header: group titles spanning their columns, then the stat labels.
+    grp_ths = ''.join(
+        f'<th class="grp" colspan="{span}">{escape(title)}</th>'
+        for title, span in group_spans
+    )
+    col_ths = ''.join(
+        f'<th class="sortable" data-ci="{i + 1}">{escape(label)}</th>'
+        for i, (_col, label) in enumerate(flat)
+    )
+    thead = (
+        '<thead>'
+        '<tr><th class="sortable" data-ci="0" rowspan="2">Sequence</th>'
+        f'{grp_ths}</tr>'
+        f'<tr>{col_ths}</tr>'
+        '</thead>'
+    )
+
+    def _row_html(label, values, is_consensus=False):
+        """
+        Build one table row: a leading label cell then a cell per flat column.
+
+        Parameters
+        ----------
+        label : str
+            The row header (a sequence id or the consensus id).
+        values : dict
+            Column-name to value; missing columns render as an en-dash.
+        is_consensus : bool, optional
+            Whether this is the deRIP-consensus row (adds a marker class).
+
+        Returns
+        -------
+        str
+            The ``<tr>`` element for this row.
+        """
+        cells = [f'<th scope="row">{escape(str(label))}</th>']
+        for col, _lab in flat:
+            value = values.get(col)
+            if col == 'RIP_total' and value is not None:
+                text, css = str(int(value)), ''
+            else:
+                text, css = _format_cell(col, value)
+            cls = f' class="value {css}"'.rstrip() if css else ' class="value"'
+            cells.append(f'<td{cls}>{text}</td>')
+        tr_cls = ' class="consensus-row"' if is_consensus else ''
+        return f'<tr{tr_cls}>{"".join(cells)}</tr>'
+
+    rows = []
+    for i in range(len(df)):
+        row = df.iloc[i]
+        values = {col: row[col] for col, _lab in flat if col in row.index}
+        values['RIP_total'] = int(row['RIP_fwd']) + int(row['RIP_rev'])
+        rows.append(_row_html(row['ID'], values))
+
+    # The deRIP consensus row: GC + CRI/PI/SI only; RIP/RSI columns stay None so
+    # _format_cell renders them as an en-dash (not applicable to the ancestor).
+    consensus_seq = derip.get_consensus_string()
+    cri, pi, si = derip.calculate_cri(consensus_seq)
+    consensus_values = {
+        'GC': gc_fraction(consensus_seq) * 100,
+        'CRI': cri,
+        'PI': pi,
+        'SI': si,
+    }
+    rows.append(_row_html(derip.consensus.id, consensus_values, is_consensus=True))
+
+    return (
+        '<div class="stats-scroll">'
+        f'<table class="psr-stats">{thead}<tbody>{"".join(rows)}</tbody></table>'
+        '</div>'
+    )
+
+
+def _overview_html(derip, cds_tracks, fasta_data=None, downloads=(), df=None):
     """
     Build the report's front (overview) page: the full alignment + consensus.
 
@@ -1134,6 +1312,9 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=()):
     downloads : sequence of tuple, optional
         ``(label, filename, text)`` download buttons rendered above the figure as
         self-contained ``data:`` links.
+    df : pandas.DataFrame, optional
+        The per-sequence statistics; when given, a sortable all-sequence stats
+        table (plus the deRIP consensus row) is added below the alignment figure.
 
     Returns
     -------
@@ -1159,6 +1340,17 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=()):
         )
     toolbar = f'<div class="psr-toolbar">{"".join(tools)}</div>' if tools else ''
 
+    stats_section = ''
+    if df is not None:
+        stats_section = (
+            '<h3>Summary statistics</h3>'
+            '<p class="desc">Per-sequence statistics for every sequence plus the '
+            'deRIP-corrected consensus (its RIP-event and strand-bias columns are '
+            'not applicable and shown as &ndash;). Click any column heading to '
+            'sort.</p>'
+            f'{_overview_stats_table_html(df, derip)}'
+        )
+
     return (
         '<section class="seq-panel" data-index="overview" hidden>'
         f'<h2>Overview <span class="seqlen">({n_total} sequences &times; '
@@ -1170,6 +1362,7 @@ def _overview_html(derip, cds_tracks, fasta_data=None, downloads=()):
         'annotation to view its FASTA.</p>'
         f'{toolbar}'
         f'<div class="aln-scroll">{svg}</div>'
+        f'{stats_section}'
         '</section>'
     )
 
@@ -1408,7 +1601,7 @@ def write_per_sequence_report(
 
     # The front (overview) page — the full alignment + deRIP consensus — followed
     # by one panel per sequence.
-    panels = [_overview_html(derip, overview_track, fasta_data, downloads)]
+    panels = [_overview_html(derip, overview_track, fasta_data, downloads, df)]
     panels += [
         _panel_html(
             derip,

--- a/src/derip2/persequence_report.py
+++ b/src/derip2/persequence_report.py
@@ -17,7 +17,9 @@ the document — without unique prefixes, later figures would borrow the first
 figure's glyphs.
 """
 
+import base64
 from html import escape
+import json
 import logging
 
 from derip2.plotting.persequence import (
@@ -86,16 +88,22 @@ _STAT_SECTIONS = (
 )
 
 
-def _inject_svg_tooltips(svg, prefix, titles):
+def _inject_svg_tooltips(svg, prefix, titles, fasta_keys=None):
     """
-    Tag named ``<g>`` groups with a ``data-tip`` attribute for custom tooltips.
+    Tag named ``<g>`` groups with ``data-tip`` (and optional ``data-fasta``).
 
     Matplotlib writes an artist's ``gid`` as ``<g id="gid">``; ``_figure_to_svg``
     then namespaces every id with ``prefix``. Adding a ``data-tip`` attribute to
     that group's opening tag lets the report's own JavaScript show a floating
     tooltip with no delay and pin it on click (a native ``<title>`` would impose
     a ~1 s browser delay and never appear on click). ``aria-label`` mirrors the
-    text so assistive technology can still announce it.
+    text so assistive technology can still announce it. When ``fasta_keys`` maps a
+    ``gid`` to a payload key, a ``data-fasta`` attribute is added too so a click on
+    that group opens the FASTA popup (see :data:`_PSR_SCRIPT`).
+
+    Both attributes are written in a single pass per ``gid`` because they share
+    one opening tag: a second ``str.replace`` for the same ``gid`` would no longer
+    match once the tag had grown its first attribute.
 
     Parameters
     ----------
@@ -105,18 +113,69 @@ def _inject_svg_tooltips(svg, prefix, titles):
         The id prefix applied by :func:`derip2.report._figure_to_svg`.
     titles : dict of str to str
         Maps each artist ``gid`` to its tooltip text.
+    fasta_keys : dict of str to str, optional
+        Maps a ``gid`` to a FASTA-payload key; those groups gain a ``data-fasta``
+        attribute. ``gid``\\s present here but absent from ``titles`` are still
+        tagged (with ``data-fasta`` only).
 
     Returns
     -------
     str
-        The SVG with ``data-tip``/``aria-label`` attributes added.
+        The SVG with ``data-tip``/``aria-label``/``data-fasta`` attributes added.
     """
-    for gid, text in titles.items():
+    fasta_keys = fasta_keys or {}
+    for gid in dict.fromkeys((*titles, *fasta_keys)):
         opening = f'<g id="{prefix}{gid}">'
-        esc = escape(text, quote=True)
-        replacement = f'<g id="{prefix}{gid}" data-tip="{esc}" aria-label="{esc}">'
+        attrs = ''
+        if gid in titles:
+            esc = escape(titles[gid], quote=True)
+            attrs += f' data-tip="{esc}" aria-label="{esc}"'
+        if gid in fasta_keys:
+            attrs += f' data-fasta="{escape(fasta_keys[gid], quote=True)}"'
+        replacement = f'<g id="{prefix}{gid}"{attrs}>'
         svg = svg.replace(opening, replacement, 1)
     return svg
+
+
+def _fasta_record(name, seq, width=60):
+    """
+    Format a name and sequence as a wrapped FASTA record string.
+
+    Parameters
+    ----------
+    name : str
+        The record identifier (the header after ``>``).
+    seq : str
+        The sequence; wrapped to ``width`` characters per line.
+    width : int, optional
+        Line-wrap width (default: 60).
+
+    Returns
+    -------
+    str
+        A FASTA record ending in a newline.
+    """
+    lines = [seq[i : i + width] for i in range(0, len(seq), width)] or ['']
+    body = '\n'.join(lines)
+    return f'>{name}\n{body}\n'
+
+
+def _data_uri(text):
+    """
+    Encode text as a base64 ``data:`` URI for a self-contained download link.
+
+    Parameters
+    ----------
+    text : str
+        The payload (e.g. a FASTA document).
+
+    Returns
+    -------
+    str
+        A ``data:text/plain;charset=utf-8;base64,...`` URI.
+    """
+    b64 = base64.b64encode(text.encode('utf-8')).decode('ascii')
+    return f'data:text/plain;charset=utf-8;base64,{b64}'
 
 
 def _zoom_control():
@@ -344,7 +403,101 @@ _PSR_STYLE = """
   box-shadow: 0 2px 8px rgba(0, 0, 0, .25);
 }
 .psr-tip[hidden] { display: none; }
+
+/* Overview download / view-FASTA toolbar. */
+.psr-toolbar {
+  display: flex; flex-wrap: wrap; gap: .5rem; margin: 0 0 .8rem;
+}
+.psr-btn {
+  font: inherit; font-size: 13px; padding: .35rem .8rem; cursor: pointer;
+  background: var(--page); color: var(--ink); border: 1px solid var(--rule);
+  border-radius: 6px; text-decoration: none; display: inline-block;
+}
+.psr-btn:hover { border-color: var(--muted); }
+
+/* The overview annotation groups and the deRIP consensus row become clickable:
+   pointer-events:all lets even the invisible consensus overlay catch a click. */
+.aln-scroll [data-fasta], .aln-scroll [data-fasta] * {
+  cursor: pointer; pointer-events: all;
+}
+
+/* Click-to-view FASTA modal: a centred dialog over a dimming backdrop. */
+.psr-modal { position: fixed; inset: 0; z-index: 60; }
+.psr-modal[hidden] { display: none; }
+.psr-modal-backdrop {
+  position: absolute; inset: 0; background: rgba(0, 0, 0, .45);
+}
+.psr-modal-box {
+  position: relative; margin: 6vh auto 0; max-width: 680px; width: calc(100% - 2rem);
+  max-height: 84vh; display: flex; flex-direction: column;
+  background: var(--page); color: var(--ink);
+  border: 1px solid var(--rule); border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, .35);
+}
+.psr-modal-head {
+  display: flex; align-items: center; gap: .5rem;
+  padding: .7rem 1rem; border-bottom: 1px solid var(--rule);
+}
+.psr-modal-title { font-weight: 600; word-break: break-all; }
+.psr-modal-x {
+  margin-left: auto; font: inherit; font-size: 1.3rem; line-height: 1;
+  background: none; border: none; color: var(--muted); cursor: pointer;
+  padding: 0 .2rem;
+}
+.psr-modal-x:hover { color: var(--ink); }
+.psr-tabs { display: flex; gap: .3rem; padding: .6rem 1rem 0; }
+.psr-tab {
+  font: inherit; font-size: 13px; padding: .3rem .8rem; cursor: pointer;
+  background: var(--surface); color: var(--ink-2);
+  border: 1px solid var(--rule); border-bottom: none;
+  border-radius: 6px 6px 0 0;
+}
+.psr-tab.is-active { color: var(--ink); font-weight: 600; background: var(--page); }
+.psr-tab[hidden] { display: none; }
+.psr-fasta {
+  margin: 0; padding: .8rem 1rem; overflow: auto; flex: 1 1 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px; line-height: 1.45; white-space: pre; word-break: normal;
+  background: #fcfcfb; color: #111;
+}
+.psr-modal-foot {
+  display: flex; align-items: center; gap: .8rem;
+  padding: .6rem 1rem; border-top: 1px solid var(--rule);
+}
+.psr-transl-note { color: var(--muted); font-size: 12.5px; margin: 0; }
+.psr-transl-note[hidden] { display: none; }
+.psr-copy {
+  font: inherit; font-size: 13px; padding: .3rem .9rem; cursor: pointer;
+  background: var(--page); color: var(--ink); border: 1px solid var(--rule);
+  border-radius: 6px;
+}
+.psr-copy:hover { border-color: var(--muted); }
 """
+
+# The click-to-view FASTA modal, injected once per report. Populated and shown by
+# the popup handler in ``_PSR_SCRIPT``; ``data-close`` marks the backdrop and the
+# × button so a single handler can dismiss it.
+_MODAL_HTML = (
+    '<div class="psr-modal" id="psr-modal" hidden>'
+    '<div class="psr-modal-backdrop" data-close></div>'
+    '<div class="psr-modal-box" role="dialog" aria-modal="true" '
+    'aria-labelledby="psr-modal-title">'
+    '<div class="psr-modal-head">'
+    '<span class="psr-modal-title" id="psr-modal-title"></span>'
+    '<button class="psr-modal-x" type="button" data-close aria-label="Close">'
+    '&times;</button>'
+    '</div>'
+    '<div class="psr-tabs" id="psr-tabs">'
+    '<button class="psr-tab is-active" type="button" data-tab="nt">Nucleotide</button>'
+    '<button class="psr-tab" type="button" data-tab="aa">Translation</button>'
+    '</div>'
+    '<pre class="psr-fasta" id="psr-fasta"></pre>'
+    '<div class="psr-modal-foot">'
+    '<button class="psr-copy" id="psr-copy" type="button">Copy</button>'
+    '<p class="psr-transl-note" id="psr-transl-note" hidden></p>'
+    '</div>'
+    '</div></div>'
+)
 
 # Dependency-free navigation. Beyond stepping between panels, it preserves both
 # scroll axes so content stays aligned when flipping pages: the window's vertical
@@ -486,12 +639,105 @@ _PSR_SCRIPT = """
       if (g) { hideTip(); }
     });
     document.addEventListener('click', function (e) {
+      // A group with a FASTA payload opens the popup instead of pinning a tip.
+      var fa = e.target.closest && e.target.closest('[data-fasta]');
+      if (fa) {
+        openFastaModal(fa.getAttribute('data-fasta'));
+        pinned = false; tip.setAttribute('hidden', '');
+        return;
+      }
       var g = e.target.closest && e.target.closest('[data-tip]');
       if (g) {
         pinned = true; showTip(g.getAttribute('data-tip'), e);
       } else {
         pinned = false; tip.setAttribute('hidden', '');
       }
+    });
+  }
+
+  // Click-to-view FASTA popup. The payloads are embedded as JSON; each clickable
+  // group (a CDS annotation, or the deRIP consensus row) carries a data-fasta key.
+  var fastaData = {};
+  var dataEl = document.getElementById('psr-fasta-data');
+  if (dataEl) { try { fastaData = JSON.parse(dataEl.textContent); } catch (err) {} }
+  var modal = document.getElementById('psr-modal');
+  var modalTitle = document.getElementById('psr-modal-title');
+  var fastaPre = document.getElementById('psr-fasta');
+  var translNote = document.getElementById('psr-transl-note');
+  var copyBtn = document.getElementById('psr-copy');
+  var modalTabs = modal
+    ? Array.prototype.slice.call(modal.querySelectorAll('.psr-tab')) : [];
+  var fastaCurrent = null;   // the active payload
+  var activeTab = 'nt';
+
+  function fallbackCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); } catch (err) {}
+    document.body.removeChild(ta);
+  }
+
+  function renderFastaTab() {
+    if (!fastaCurrent) return;
+    var aaTab = modalTabs.filter(function (t) {
+      return t.getAttribute('data-tab') === 'aa';
+    })[0];
+    var hasAa = !!fastaCurrent.aa;
+    if (aaTab) {
+      if (hasAa) { aaTab.removeAttribute('hidden'); }
+      else { aaTab.setAttribute('hidden', ''); }
+    }
+    if (activeTab === 'aa' && !hasAa) { activeTab = 'nt'; }
+    modalTabs.forEach(function (t) {
+      t.classList.toggle('is-active', t.getAttribute('data-tab') === activeTab);
+    });
+    fastaPre.textContent = activeTab === 'aa' ? fastaCurrent.aa : fastaCurrent.nt;
+    if (activeTab === 'aa' && fastaCurrent.table != null) {
+      translNote.textContent =
+        'Translation — NCBI genetic code table ' + fastaCurrent.table + '.';
+      translNote.removeAttribute('hidden');
+    } else {
+      translNote.setAttribute('hidden', '');
+    }
+  }
+
+  function openFastaModal(key) {
+    if (!modal || !fastaData[key]) return;
+    fastaCurrent = fastaData[key];
+    activeTab = 'nt';
+    modalTitle.textContent = fastaCurrent.name;
+    renderFastaTab();
+    modal.removeAttribute('hidden');
+  }
+  function closeFastaModal() {
+    if (modal) { modal.setAttribute('hidden', ''); }
+    fastaCurrent = null;
+  }
+
+  if (modal) {
+    modalTabs.forEach(function (t) {
+      t.addEventListener('click', function () {
+        activeTab = t.getAttribute('data-tab'); renderFastaTab();
+      });
+    });
+    modal.addEventListener('click', function (e) {
+      if (e.target.closest('[data-close]')) { closeFastaModal(); }
+    });
+    copyBtn.addEventListener('click', function () {
+      var text = fastaPre.textContent;
+      function done() {
+        var old = copyBtn.textContent; copyBtn.textContent = 'Copied!';
+        setTimeout(function () { copyBtn.textContent = old; }, 1200);
+      }
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, function () {
+          fallbackCopy(text); done();
+        });
+      } else { fallbackCopy(text); done(); }
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !modal.hasAttribute('hidden')) { closeFastaModal(); }
     });
   }
 
@@ -808,7 +1054,7 @@ def _panel_html(
     )
 
 
-def _overview_svg(derip, cds_tracks):
+def _overview_svg(derip, cds_tracks, fasta_data=None):
     """
     Render the full ``--plot`` alignment figure and return it as inline SVG.
 
@@ -816,7 +1062,9 @@ def _overview_svg(derip, cds_tracks):
     ``--plot`` flag writes, including the deRIP corrected consensus row). The
     figure is rendered to inline SVG so the axes, annotation track and consensus
     stay crisp vector (the coloured base grid remains a single embedded raster);
-    the annotation groups carry ``data-tip`` attributes for the report tooltips.
+    the annotation groups carry ``data-tip`` attributes for the report tooltips
+    and, where a FASTA payload exists, a ``data-fasta`` attribute so a click opens
+    the sequence popup.
 
     Parameters
     ----------
@@ -824,12 +1072,16 @@ def _overview_svg(derip, cds_tracks):
         The analysed DeRIP object.
     cds_tracks : list or None
         Rich per-gene CDS tracks ``(exon_spans, strand, stop_columns, label,
-        colour)`` to draw above the consensus (``--gff``), or None.
+        colour, cds_id)`` to draw below the consensus (``--gff``), or None.
+    fasta_data : dict, optional
+        FASTA popup payloads keyed by CDS id (plus ``'__derip__'``). Used to add
+        ``data-fasta`` attributes to the matching annotation groups and the
+        consensus row.
 
     Returns
     -------
     str
-        The inline ``<svg>`` fragment (id-prefixed, tooltip-tagged).
+        The inline ``<svg>`` fragment (id-prefixed, tooltip/fasta-tagged).
     """
     import matplotlib.pyplot as plt
 
@@ -845,14 +1097,29 @@ def _overview_svg(derip, cds_tracks):
         cds_tracks=cds_tracks,
     )
     try:
+        titles = getattr(fig, 'annotation_titles', {})
+        # Map each clickable group's gid to its FASTA-payload key: the consensus
+        # row (gid 'deripseq') opens the deRIP sequence; each CDS exon group opens
+        # its CDS (the tooltip text is 'cdsID — CDS exon x/y', so its id prefixes
+        # the text). Only groups with a payload become clickable.
+        valid = set(fasta_data or ())
+        fasta_keys = {}
+        for gid, text in titles.items():
+            if gid == 'deripseq':
+                if '__derip__' in valid:
+                    fasta_keys[gid] = '__derip__'
+            else:
+                cid = text.split(' — ', 1)[0]
+                if cid in valid:
+                    fasta_keys[gid] = cid
         svg = _figure_to_svg(fig, 'ovw-', tight=True)
-        svg = _inject_svg_tooltips(svg, 'ovw-', getattr(fig, 'annotation_titles', {}))
+        svg = _inject_svg_tooltips(svg, 'ovw-', titles, fasta_keys)
     finally:
         plt.close(fig)
     return svg
 
 
-def _overview_html(derip, cds_tracks):
+def _overview_html(derip, cds_tracks, fasta_data=None, downloads=()):
     """
     Build the report's front (overview) page: the full alignment + consensus.
 
@@ -862,15 +1129,36 @@ def _overview_html(derip, cds_tracks):
         The analysed DeRIP object.
     cds_tracks : list or None
         Rich per-gene CDS tracks for the alignment figure (``--gff``), or None.
+    fasta_data : dict, optional
+        FASTA popup payloads (see :func:`_overview_svg`); enables click-to-view.
+    downloads : sequence of tuple, optional
+        ``(label, filename, text)`` download buttons rendered above the figure as
+        self-contained ``data:`` links.
 
     Returns
     -------
     str
         The overview ``<section class="seq-panel">`` (first page of the deck).
     """
-    svg = _overview_svg(derip, cds_tracks)
+    svg = _overview_svg(derip, cds_tracks, fasta_data)
     n_total = len(derip.alignment)
     n_cols = derip.alignment.get_alignment_length()
+
+    # Download links (self-contained data: URIs) plus a button to view the deRIP
+    # sequence FASTA in the popup (the consensus row is also clickable).
+    tools = []
+    for label, filename, text in downloads:
+        tools.append(
+            f'<a class="psr-btn" download="{escape(filename, quote=True)}" '
+            f'href="{_data_uri(text)}">{escape(label)}</a>'
+        )
+    if fasta_data and '__derip__' in fasta_data:
+        tools.append(
+            '<button class="psr-btn" type="button" data-fasta="__derip__">'
+            'View deRIP FASTA</button>'
+        )
+    toolbar = f'<div class="psr-toolbar">{"".join(tools)}</div>' if tools else ''
+
     return (
         '<section class="seq-panel" data-index="overview" hidden>'
         f'<h2>Overview <span class="seqlen">({n_total} sequences &times; '
@@ -878,7 +1166,9 @@ def _overview_html(derip, cds_tracks):
         '<h3>Full alignment</h3>'
         '<p class="desc">The whole alignment with RIP markup and, beneath it, the '
         'deRIP-corrected consensus with corrected positions; any gene-annotation '
-        'track is drawn below the consensus.</p>'
+        'track is drawn below the consensus. Click the deRIP sequence or a CDS '
+        'annotation to view its FASTA.</p>'
+        f'{toolbar}'
         f'<div class="aln-scroll">{svg}</div>'
         '</section>'
     )
@@ -1001,6 +1291,24 @@ def write_per_sequence_report(
     spectra = derip.calculate_spectra(partition_by='row')
     downstream = derip.calculate_spectra(partition_by='row', context='downstream')
 
+    # FASTA payloads for the overview downloads + click-to-view popups. The deRIP
+    # sequence is always available; CDS records are added when a GFF is supplied.
+    # Keyed for the popup JS: '__derip__' for the corrected consensus, then one
+    # entry per CDS id. Each value carries the record name, its nucleotide FASTA,
+    # its translation FASTA (CDS only) and the genetic-code table used.
+    derip_name = derip.consensus.id
+    derip_seq = derip.get_consensus_string()
+    derip_fasta = _fasta_record(derip_name, derip_seq)
+    fasta_data = {
+        '__derip__': {
+            'name': derip_name,
+            'nt': derip_fasta,
+            'aa': None,
+            'table': None,
+        }
+    }
+    cds_multifasta = None
+
     # Optional gene-effect data. Parsed once and shared across panels.
     genes_by_seqid = {}
     effects_by_seq = {}
@@ -1012,6 +1320,7 @@ def write_per_sequence_report(
 
         from derip2.annotation import (
             DEFAULT_ANNOTATION_COLORS,
+            _read_coding_bases,
             cds_alignment_columns,
             cds_display_id,
             cds_exon_spans,
@@ -1071,11 +1380,35 @@ def write_per_sequence_report(
             for gene, cols, exon_spans, colour in cds_gene_cols
         ]
 
+        # Per-CDS FASTA payloads, projected onto the deRIP consensus: the coding
+        # nucleotides (gaps dropped, minus strand complemented) and the
+        # deRIP-restored protein (keyed by parent transcript). Keyed by CDS id for
+        # the popup and concatenated into a downloadable multi-FASTA.
+        cds_records = []
+        for gene, cols, _exon_spans, _colour in cds_gene_cols:
+            cds_id = cds_display_id(gene)
+            nt, _kept = _read_coding_bases(consensus_row, cols, gene.strand)
+            aa = deripd_aa.get(gene.gene_id, '')
+            fasta_data[cds_id] = {
+                'name': cds_id,
+                'nt': _fasta_record(cds_id, nt),
+                'aa': _fasta_record(cds_id, aa) if aa else None,
+                'table': genetic_code,
+            }
+            cds_records.append(_fasta_record(cds_id, nt))
+        cds_multifasta = ''.join(cds_records) if cds_records else None
+
+    # Overview download buttons: the deRIP sequence, and (with a GFF) every CDS
+    # nucleotide sequence as mapped onto the deRIP consensus.
+    downloads = [('⭳ deRIP sequence (FASTA)', f'{derip_name}.fasta', derip_fasta)]
+    if cds_multifasta:
+        downloads.append(('⭳ CDS features (FASTA)', 'deRIP_cds.fasta', cds_multifasta))
+
     indices, truncated = _select_rows(df, max_seqs)
 
     # The front (overview) page — the full alignment + deRIP consensus — followed
     # by one panel per sequence.
-    panels = [_overview_html(derip, overview_track)]
+    panels = [_overview_html(derip, overview_track, fasta_data, downloads)]
     panels += [
         _panel_html(
             derip,
@@ -1114,6 +1447,10 @@ def write_per_sequence_report(
         '</div>'
     )
 
+    # FASTA popup payloads, embedded as JSON for the click-to-view modal. The
+    # ``</`` escape keeps a sequence/name from prematurely closing the <script>.
+    fasta_json = json.dumps(fasta_data).replace('</', '<\\/')
+
     html = (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
@@ -1128,7 +1465,9 @@ def write_per_sequence_report(
         + '<footer>Generated by deRIP2. Figures are inline SVG and render on '
         'their own light surface so the colourblind-safe palette holds.</footer>'
         '<div class="psr-tip" id="psr-tip" hidden></div>'
-        f'<script>{_PSR_SCRIPT}</script>'
+        + _MODAL_HTML
+        + f'<script type="application/json" id="psr-fasta-data">{fasta_json}</script>'
+        + f'<script>{_PSR_SCRIPT}</script>'
         '</main></body></html>'
     )
 

--- a/src/derip2/persequence_report.py
+++ b/src/derip2/persequence_report.py
@@ -22,6 +22,8 @@ from html import escape
 import json
 import logging
 
+from tqdm import tqdm
+
 from derip2.plotting.persequence import (
     NONRIP_COLOR,
     PRODUCT_COLOR,
@@ -1597,9 +1599,16 @@ def write_per_sequence_report(
     a correspondingly large file; ``max_seqs`` is the recommended mitigation for
     large alignments.
     """
+    # This whole routine can take a while on large alignments (one panel of ~6
+    # figures per sequence, plus the per-row spectra and the overview figure), so
+    # each expensive stage announces itself and the per-panel loop shows a bar.
+    n_seqs = len(derip.alignment)
+    logger.info(f'Building per-sequence report for {n_seqs} sequences...')
+
     df = derip.summarize_stats(ambiguous=ambiguous)
     # One sample column per sequence, measured against the reconstructed
     # ancestor, in each context. Computed once and reused across every panel.
+    logger.info('Computing per-sequence mutation spectra...')
     spectra = derip.calculate_spectra(partition_by='row')
     downstream = derip.calculate_spectra(partition_by='row', context='downstream')
 
@@ -1644,6 +1653,7 @@ def write_per_sequence_report(
             warn_unmatched_seqids,
         )
 
+        logger.info(f'Computing gene effects from {gff}...')
         genes_by_seqid = parse_gff3(gff)
         warn_unmatched_seqids(genes_by_seqid, [rec.id for rec in derip.alignment])
         effects_by_seq = compute_effects_for_alignment(
@@ -1725,10 +1735,15 @@ def write_per_sequence_report(
     row_to_panel = {row_index: pos for pos, row_index in enumerate(indices, start=1)}
 
     # The front (overview) page — the full alignment + deRIP consensus — followed
-    # by one panel per sequence.
+    # by one panel per sequence. The overview renders the whole-alignment figure
+    # (slow on many rows/columns), so it gets its own message.
+    logger.info('Rendering overview page (full alignment + summary)...')
     panels = [
         _overview_html(derip, overview_track, fasta_data, downloads, df, row_to_panel)
     ]
+    # The per-sequence panels dominate the runtime on large alignments (each is
+    # ~6 matplotlib figures rendered to inline SVG), so show a progress bar.
+    logger.info(f'Rendering {len(indices)} sequence panels...')
     panels += [
         _panel_html(
             derip,
@@ -1743,8 +1758,16 @@ def write_per_sequence_report(
             cds_gene_cols,
             genetic_code,
         )
-        for panel_number, row_index in enumerate(indices, start=1)
+        for panel_number, row_index in tqdm(
+            enumerate(indices, start=1),
+            total=len(indices),
+            desc='Rendering sequence panels',
+            unit='seq',
+            ncols=80,
+            leave=False,
+        )
     ]
+    logger.info('Assembling HTML report...')
 
     heading = escape(title or 'deRIP2 per-sequence report')
     n_total = len(df)

--- a/src/derip2/persequence_report.py
+++ b/src/derip2/persequence_report.py
@@ -684,13 +684,22 @@ def _panel_html(
     # premature stops). One track band per gene, drawn below the deRIP row.
     cds_tracks = []
     if cds_gene_cols:
-        from derip2.annotation import cds_stop_columns
+        from derip2.annotation import cds_display_id, cds_stop_columns
 
         for gene, cols, exon_spans, colour in cds_gene_cols:
             stops = cds_stop_columns(
                 gene, cls.arr[row_index], cols, genetic_code=genetic_code
             )
-            cds_tracks.append((exon_spans, gene.strand, stops, gene.gene_id, colour))
+            cds_tracks.append(
+                (
+                    exon_spans,
+                    gene.strand,
+                    stops,
+                    gene.gene_id,
+                    colour,
+                    cds_display_id(gene),
+                )
+            )
 
     strip = sequence_row_strip(
         cls,
@@ -868,7 +877,8 @@ def _overview_html(derip, cds_tracks):
         f'{n_cols} columns)</span>{_zoom_control()}</h2>'
         '<h3>Full alignment</h3>'
         '<p class="desc">The whole alignment with RIP markup and, beneath it, the '
-        'deRIP-corrected consensus with corrected positions.</p>'
+        'deRIP-corrected consensus with corrected positions; any gene-annotation '
+        'track is drawn below the consensus.</p>'
         f'<div class="aln-scroll">{svg}</div>'
         '</section>'
     )
@@ -1003,6 +1013,7 @@ def write_per_sequence_report(
         from derip2.annotation import (
             DEFAULT_ANNOTATION_COLORS,
             cds_alignment_columns,
+            cds_display_id,
             cds_exon_spans,
             cds_stop_columns,
             compute_effects_for_alignment,
@@ -1055,6 +1066,7 @@ def write_per_sequence_report(
                 cds_stop_columns(gene, consensus_row, cols, genetic_code=genetic_code),
                 gene.gene_id,
                 colour,
+                cds_display_id(gene),
             )
             for gene, cols, exon_spans, colour in cds_gene_cols
         ]

--- a/src/derip2/plotting/minialign.py
+++ b/src/derip2/plotting/minialign.py
@@ -429,11 +429,13 @@ def drawMiniAlignment(
     width_padding = 0.2  # Add 0.2 inches of padding to width
     height_padding = 1  # Add 1 inch of padding to height
 
-    # Create the figure. The alignment always occupies the top row (ratio 4); an
-    # optional gene-annotation track and the optional deRIP-consensus row each add
-    # their own stacked sub-plot below it. Building them as separate axes (rather
-    # than drawing the track onto the alignment axis) keeps the SVG chrome clean
-    # and lets the track carry its own tooltips.
+    # Create the figure. The alignment always occupies the top row (ratio 4); the
+    # optional deRIP-consensus row sits directly below it, and the optional
+    # gene-annotation track sits below the consensus (inside the deRIP-consensus
+    # section) so a gene's exon/stop glyphs read against the corrected sequence
+    # they annotate. Building them as separate axes (rather than drawing the track
+    # onto the alignment axis) keeps the SVG chrome clean and lets the track carry
+    # its own tooltips.
     f = plt.figure(figsize=(width + width_padding, height + height_padding), dpi=dpi)
 
     n_ann_rows = 0
@@ -443,24 +445,25 @@ def drawMiniAlignment(
         n_ann_rows = max(row for *_rest, row in annotation_track) + 1
     ann_ratio = 0.5 * n_ann_rows if n_ann_rows else 0.0
 
+    # Stack order top -> bottom: alignment, consensus, annotation track.
     ratios = [4.0]
-    if ann_ratio:
-        ratios.append(ann_ratio)
     if consensus_seq is not None:
         ratios.append(1.0)
+    if ann_ratio:
+        ratios.append(ann_ratio)
 
     gs = f.add_gridspec(len(ratios), 1, height_ratios=ratios)
     a = f.add_subplot(gs[0])
 
     row_i = 1
-    ann_ax = None
-    if ann_ratio:
-        ann_ax = f.add_subplot(gs[row_i])
-        row_i += 1
-
     consensus_ax = None
     if consensus_seq is not None:
         consensus_ax = f.add_subplot(gs[row_i])
+        row_i += 1
+
+    ann_ax = None
+    if ann_ratio:
+        ann_ax = f.add_subplot(gs[row_i])
 
     # Position adjustments - keep the same relative positioning
     if consensus_ax is not None or ann_ax is not None:
@@ -617,8 +620,8 @@ def drawMiniAlignment(
     if column_ranges:
         addColumnRangeMarkers(a, column_ranges, ali_height)
 
-    # Add a gene-annotation track in its own sub-plot between the alignment and
-    # the deRIP consensus. Rich CDS tracks (rounded exon segments joined across
+    # Add a gene-annotation track in its own sub-plot below the deRIP consensus
+    # (within the consensus section). Rich CDS tracks (rounded exon segments joined across
     # introns by a coloured midline, a strand arrowhead, and a bold red '*' at
     # each stop codon in the projected reading frame) are preferred; a flat span
     # list is the fallback. The returned gid -> label map is attached to the

--- a/src/derip2/plotting/minialign.py
+++ b/src/derip2/plotting/minialign.py
@@ -697,6 +697,24 @@ def drawMiniAlignment(
         for spine in consensus_ax.spines.values():
             spine.set_visible(False)
 
+        # A full-width, invisible patch over the consensus row carrying a gid so
+        # the HTML report can make the whole deRIP'd sequence clickable (a click
+        # opens its FASTA popup). Drawn at a high zorder so it stays vector even
+        # when a wide alignment rasterizes the consensus cells (zorder < 200) and
+        # its gid group survives in the SVG. In file output it is inert and unseen.
+        click_patch = matplotlib.patches.Rectangle(
+            (-0.5, -0.5),
+            len(consensus_seq),
+            2.0,
+            facecolor='none',
+            edgecolor='none',
+            zorder=250,
+        )
+        click_patch.set_gid('deripseq')
+        consensus_ax.add_patch(click_patch)
+        if isinstance(getattr(f, 'annotation_titles', None), dict):
+            f.annotation_titles['deripseq'] = 'deRIP consensus — click for FASTA'
+
         # Add vertical grid lines (only when columns are few enough to see them;
         # see the alignment-axis note above).
         if len(consensus_seq) <= 500:

--- a/src/derip2/plotting/persequence.py
+++ b/src/derip2/plotting/persequence.py
@@ -630,7 +630,11 @@ def _draw_annotation_tracks(ax, tracks, n_cols, fig_w, show_labels=True):
     ax : matplotlib.axes.Axes
         The annotation sub-plot axis (shares the column x-axis with the rows).
     tracks : list of tuple
-        ``(exon_spans, strand, stop_columns, label, colour)`` per gene.
+        ``(exon_spans, strand, stop_columns, label, colour[, cds_id])`` per gene.
+        ``label`` is the y-axis row label (the parent transcript / gene id); the
+        optional 6th element ``cds_id`` is the CDS ``ID`` attribute used for the
+        hover tooltip so distinct CDS isoforms sharing one transcript stay
+        distinguishable. Legacy 5-tuples fall back to ``label`` for the tooltip.
     n_cols : int
         Number of alignment columns (for the shared x-range).
     fig_w : float
@@ -660,7 +664,12 @@ def _draw_annotation_tracks(ax, tracks, n_cols, fig_w, show_labels=True):
     # after SVG export, an individual <title> tooltip. Exon counts are small.
     titles = {}
     gid_n = 0
-    for t, (exon_spans, strand, stop_cols, label, colour) in enumerate(tracks):
+    for t, track in enumerate(tracks):
+        exon_spans, strand, stop_cols, label, colour = track[:5]
+        # The hover tooltip identifies the CDS by its own ``ID`` (6th element);
+        # the y-axis row label keeps the parent transcript id. Legacy 5-tuples
+        # fall back to the transcript id for the tooltip too.
+        tip_id = track[5] if len(track) > 5 else label
         center = t + 0.55
         y0, y1 = center - half_h, center + half_h
         spans = [(float(s), float(e)) for s, e in exon_spans]
@@ -684,7 +693,7 @@ def _draw_annotation_tracks(ax, tracks, n_cols, fig_w, show_labels=True):
                 exon_no = n_exons - j if strand == '-' else j + 1
                 gid = f'anntip{gid_n}'
                 gid_n += 1
-                titles[gid] = f'{label} — CDS exon {exon_no}/{n_exons}'
+                titles[gid] = f'{tip_id} — CDS exon {exon_no}/{n_exons}'
                 patch = PathPatch(
                     _gene_exon_path(
                         s - 0.5, e + 0.5, y0, y1, strand, rx, half_h * 0.6, arrow_len
@@ -714,7 +723,7 @@ def _draw_annotation_tracks(ax, tracks, n_cols, fig_w, show_labels=True):
     if show_labels:
         ax.set_yticks([t + 0.55 for t in range(len(tracks))])
         ax.set_yticklabels(
-            [label for _s, _st, _sc, label, _c in tracks],
+            [track[3] for track in tracks],
             fontsize=TICK_LABEL_SIZE,
             color=INK_MUTED,
         )

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -17,6 +17,7 @@ from derip2.annotation import (
     Feature,
     Gene,
     cds_alignment_columns,
+    cds_display_id,
     cds_stop_columns,
     parse_gff3,
     predict_gene_effects,
@@ -40,6 +41,30 @@ def cds_gene(gene_id, seqid, strand, exons, phase=0):
         for i, (s, e) in enumerate(exons)
     ]
     return Gene(gene_id=gene_id, seqid=seqid, strand=strand, cds=features)
+
+
+def test_cds_display_id_prefers_cds_id():
+    """cds_display_id returns the CDS ID (first segment), not the parent id.
+
+    parse_gff3 groups by Parent, so gene_id is the transcript; the CDS's own ID
+    lives on each segment's feature_id and all segments of one CDS share it.
+    """
+    # Parent 'mRNA3' owns a two-segment CDS whose ID is 'cds3'.
+    cds = [
+        Feature('S4', 'CDS', 1, 6, '+', 0, {}, 'cds3', 'mRNA3'),
+        Feature('S4', 'CDS', 13, 21, '+', 0, {}, 'cds3', 'mRNA3'),
+    ]
+    gene = Gene(gene_id='mRNA3', seqid='S4', strand='+', cds=cds)
+    assert cds_display_id(gene) == 'cds3'
+
+
+def test_cds_display_id_falls_back_to_gene_id():
+    """cds_display_id falls back to gene_id when the CDS carried no ID."""
+    cds = [Feature('S1', 'CDS', 1, 9, '+', 0, {}, None, 'mRNA1')]
+    gene = Gene(gene_id='mRNA1', seqid='S1', strand='+', cds=cds)
+    assert cds_display_id(gene) == 'mRNA1'
+    # A gene with no CDS at all also falls back safely.
+    assert cds_display_id(Gene('g', 'S1', '+', [])) == 'g'
 
 
 # --- parsing ---------------------------------------------------------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+import pytest
 from click.testing import CliRunner
 
 # Import the main function
@@ -122,6 +123,46 @@ def test_main_function_with_visualization():
             f'Output alignment file not found: {output_aln}'
         )
         assert os.path.exists(output_viz), f'Visualization file not found: {output_viz}'
+
+
+@pytest.mark.parametrize('plot_format', ['svg', 'png'])
+def test_plot_format_option(plot_format):
+    """The --plot-format option controls the visualization file extension.
+
+    ``svg`` keeps the default vector output; ``png`` writes a fully rasterised
+    image (sharp at any zoom). ``drawMiniAlignment`` derives the save format from
+    the output extension, so selecting the format here must produce a matching file.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        runner = CliRunner()
+        prefix = 'FmtDeRIP'
+        result = runner.invoke(
+            main,
+            [
+                '-i',
+                'tests/data/mintest.fa',
+                '--out-dir',
+                temp_dir,
+                '--prefix',
+                prefix,
+                '--plot',
+                '--plot-format',
+                plot_format,
+            ],
+        )
+        assert result.exit_code == 0, f'Command failed with output: {result.output}'
+
+        expected = os.path.join(temp_dir, f'{prefix}_visualization.{plot_format}')
+        assert os.path.exists(expected), f'Visualization not found: {expected}'
+        # The other-format file must NOT be produced.
+        other = 'png' if plot_format == 'svg' else 'svg'
+        assert not os.path.exists(
+            os.path.join(temp_dir, f'{prefix}_visualization.{other}')
+        )
+        if plot_format == 'png':
+            # PNG magic bytes: a real rasterised image, not an SVG mislabelled.
+            with open(expected, 'rb') as handle:
+                assert handle.read(8) == b'\x89PNG\r\n\x1a\n'
 
 
 def test_noappend_option():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -165,6 +165,53 @@ def test_plot_format_option(plot_format):
                 assert handle.read(8) == b'\x89PNG\r\n\x1a\n'
 
 
+def test_spectra_ref_index_option():
+    """--spectra-ref-index selects an alternative spectra reference; bad values fail.
+
+    A valid row index produces the per-sequence report and names that reference in
+    the spectra prose; an out-of-range index is rejected as a bad CLI parameter.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        runner = CliRunner()
+        prefix = 'RefDeRIP'
+        result = runner.invoke(
+            main,
+            [
+                '-i',
+                'tests/data/mintest.fa',
+                '--out-dir',
+                temp_dir,
+                '--prefix',
+                prefix,
+                '--per-seq-report',
+                '--spectra-ref-index',
+                '0',
+            ],
+        )
+        assert result.exit_code == 0, f'Command failed with output: {result.output}'
+        report = os.path.join(temp_dir, f'{prefix}_per_sequence.html')
+        assert os.path.exists(report)
+        assert 'reference sequence' in open(report).read()
+
+        # Out-of-range index is rejected without writing a broken report.
+        bad = runner.invoke(
+            main,
+            [
+                '-i',
+                'tests/data/mintest.fa',
+                '--out-dir',
+                temp_dir,
+                '--prefix',
+                'BadRef',
+                '--per-seq-report',
+                '--spectra-ref-index',
+                '99',
+            ],
+        )
+        assert bad.exit_code != 0
+        assert 'out of range' in bad.output
+
+
 def test_noappend_option():
     """Test that the --no-append option works correctly."""
 

--- a/tests/test_minialign.py
+++ b/tests/test_minialign.py
@@ -300,6 +300,51 @@ def test_cds_tracks_rich_glyphs_and_stops(simple_alignment):
     plt.close(fig)
 
 
+def test_annotation_track_below_consensus(simple_alignment):
+    """The gene-annotation track sits below the deRIP consensus row.
+
+    The stack order is alignment -> consensus -> annotation, so a gene's glyphs
+    read against the corrected sequence they annotate.
+    """
+    from matplotlib.patches import PathPatch
+    import matplotlib.pyplot as plt
+
+    n_cols = simple_alignment.get_alignment_length()
+    fig = drawMiniAlignment(
+        simple_alignment,
+        'unused',
+        cds_tracks=[([(0, 0), (2, 3)], '+', [], 'geneX', '#efb700')],
+        consensus_seq='A' * n_cols,
+        corrected_positions=[],
+        return_figure=True,
+    )
+    consensus_ax = next(ax for ax in fig.axes if ax.get_title() == 'deRIP Consensus')
+    ann_ax = next(
+        ax for ax in fig.axes if [p for p in ax.patches if isinstance(p, PathPatch)]
+    )
+    # Lower axis => smaller y0 in figure coordinates.
+    assert ann_ax.get_position().y0 < consensus_ax.get_position().y0
+    plt.close(fig)
+
+
+def test_cds_track_tooltip_uses_cds_id(simple_alignment):
+    """A 6-tuple CDS track uses the 6th element (CDS id) for the hover tooltip.
+
+    The y-axis row label keeps the parent transcript id; the tooltip identifies
+    the CDS by its own id so isoforms sharing a transcript stay distinguishable.
+    """
+    import matplotlib.pyplot as plt
+
+    fig = drawMiniAlignment(
+        simple_alignment,
+        'unused',
+        cds_tracks=[([(0, 1)], '+', [], 'mRNA9', '#efb700', 'cds9')],
+        return_figure=True,
+    )
+    assert set(fig.annotation_titles.values()) == {'cds9 — CDS exon 1/1'}
+    plt.close(fig)
+
+
 @patch('matplotlib.figure.Figure.savefig')
 def test_drawMiniAlignment_with_title(mock_savefig, simple_alignment):
     """Test drawMiniAlignment with a title."""

--- a/tests/test_persequence_report.py
+++ b/tests/test_persequence_report.py
@@ -436,17 +436,25 @@ def test_gene_exon_path_arrow_direction():
 
 
 def test_report_annotation_tooltips(mintest_derip, gff_path, tmp_path):
-    """CDS exon segments carry a data-tip tooltip with id and exon number."""
+    """CDS exon segments carry a data-tip tooltip with the CDS id and exon number.
+
+    The tooltip identifies the CDS by its own ``ID`` attribute (``cds*``), not the
+    parent transcript (``mRNA*``), so distinct CDS isoforms sharing one transcript
+    stay distinguishable. All segments of a multi-exon CDS share the first
+    segment's ``ID``.
+    """
     out = tmp_path / 'per_seq.html'
     mintest_derip.write_per_sequence_report(str(out), gff=str(gff_path))
     html = out.read_text()
     # Custom tooltips replace native <title> (no browser delay; pin on click).
     assert '<div class="psr-tip" id="psr-tip"' in html
-    # mRNA3 is a two-exon plus-strand gene, so both exon numbers appear.
-    assert 'data-tip="mRNA3 — CDS exon 1/2"' in html
-    assert 'data-tip="mRNA3 — CDS exon 2/2"' in html
-    # A single-exon gene shows exon 1/1.
-    assert 'data-tip="mRNA1 — CDS exon 1/1"' in html
+    # cds3a/cds3b belong to two-exon plus-strand mRNA3; both segments tooltip to
+    # the first segment's CDS id (cds3a) with their exon numbers.
+    assert 'data-tip="cds3a — CDS exon 1/2"' in html
+    assert 'data-tip="cds3a — CDS exon 2/2"' in html
+    # A single-exon CDS shows exon 1/1 under its own id, not the parent transcript.
+    assert 'data-tip="cds1 — CDS exon 1/1"' in html
+    assert 'mRNA1 — CDS exon' not in html
 
 
 def test_report_total_rip_events(mintest_derip, tmp_path):

--- a/tests/test_persequence_report.py
+++ b/tests/test_persequence_report.py
@@ -601,6 +601,51 @@ def test_overview_initial_fit_and_goto_js(mintest_derip, tmp_path):
     assert "closest('[data-goto]')" in html
 
 
+def test_report_default_spectra_reference(mintest_derip, tmp_path):
+    """Without a reference index, spectra prose names the deRIP ancestor."""
+    out = tmp_path / 'per_seq.html'
+    mintest_derip.write_per_sequence_report(str(out))
+    html = out.read_text()
+    assert 'the reconstructed deRIP' in html
+    assert 'reference sequence <code>' not in html
+    assert 'chosen spectra reference' not in html
+
+
+def test_report_alternative_spectra_reference(mintest_derip, tmp_path):
+    """A spectra_ref_index names the reference and flags its self-comparison.
+
+    The per-sequence and overview spectra prose name the chosen reference
+    sequence, and that sequence's own panel notes its spectrum is empty.
+    """
+    out = tmp_path / 'per_seq.html'
+    ref_id = mintest_derip.alignment[0].id
+    mintest_derip.write_per_sequence_report(str(out), spectra_ref_index=0)
+    html = out.read_text()
+    assert f'measured against reference sequence <code>{ref_id}</code>' in html
+    assert f'relative to reference sequence <code>{ref_id}</code>' in html
+    # The reference's own panel flags the empty self-comparison exactly once.
+    assert html.count('chosen spectra reference') == 1
+
+
+def test_report_spectra_reference_negative_index(mintest_derip, tmp_path):
+    """A negative reference index is normalised (e.g. -1 = last sequence)."""
+    out = tmp_path / 'per_seq.html'
+    last_id = mintest_derip.alignment[-1].id
+    mintest_derip.write_per_sequence_report(str(out), spectra_ref_index=-1)
+    html = out.read_text()
+    assert f'reference sequence <code>{last_id}</code>' in html
+
+
+def test_report_spectra_reference_out_of_range(mintest_derip, tmp_path):
+    """An out-of-range reference index raises a clear ValueError."""
+    out = tmp_path / 'per_seq.html'
+    n = len(mintest_derip.alignment)
+    with pytest.raises(ValueError, match='out of range'):
+        mintest_derip.write_per_sequence_report(str(out), spectra_ref_index=n)
+    with pytest.raises(ValueError, match='out of range'):
+        mintest_derip.write_per_sequence_report(str(out), spectra_ref_index=-n - 1)
+
+
 def test_report_total_rip_events(mintest_derip, tmp_path):
     """The RIP-events card shows a total equal to forward + reverse."""
     out = tmp_path / 'per_seq.html'

--- a/tests/test_persequence_report.py
+++ b/tests/test_persequence_report.py
@@ -457,6 +457,55 @@ def test_report_annotation_tooltips(mintest_derip, gff_path, tmp_path):
     assert 'mRNA1 — CDS exon' not in html
 
 
+def test_overview_fasta_downloads_and_popup(mintest_derip, gff_path, tmp_path):
+    """The overview page offers FASTA downloads and click-to-view popup data.
+
+    With a GFF, the overview gets: a deRIP-sequence download, a CDS multi-FASTA
+    download, a 'View deRIP FASTA' button, the modal skeleton, and an embedded
+    JSON payload keyed by CDS id (with nucleotide + translation) and '__derip__'.
+    Clickable annotation groups and the consensus row carry data-fasta.
+    """
+    import json
+
+    out = tmp_path / 'per_seq.html'
+    mintest_derip.write_per_sequence_report(str(out), gff=str(gff_path), genetic_code=1)
+    html = out.read_text()
+
+    # Download buttons (self-contained data: URIs) + the view button + modal.
+    derip_id = mintest_derip.consensus.id  # default 'deRIPseq'
+    assert f'download="{derip_id}.fasta"' in html
+    assert 'download="deRIP_cds.fasta"' in html
+    assert 'data:text/plain;charset=utf-8;base64,' in html
+    assert 'data-fasta="__derip__">View deRIP FASTA</button>' in html
+    assert 'id="psr-modal"' in html and 'id="psr-fasta"' in html
+
+    # Clickable groups: the consensus row and each CDS carry data-fasta.
+    assert 'data-fasta="__derip__"' in html
+    for cds_id in ('cds1', 'cds2', 'cds3a'):
+        assert f'data-fasta="{cds_id}"' in html
+
+    # Embedded JSON payload: CDS entries carry nucleotide + translation + table;
+    # the deRIP entry has no translation.
+    m = re.search(r'id="psr-fasta-data">(.*?)</script>', html, re.S)
+    assert m
+    data = json.loads(m.group(1).replace('<\\/', '</'))
+    assert data['__derip__']['aa'] is None
+    assert data['cds1']['nt'].startswith('>cds1\n')
+    assert data['cds1']['aa'].startswith('>cds1\n')
+    assert data['cds1']['table'] == 1
+
+
+def test_overview_download_without_gff(mintest_derip, tmp_path):
+    """Without a GFF, the deRIP-sequence download/popup exist but no CDS export."""
+    out = tmp_path / 'per_seq.html'
+    mintest_derip.write_per_sequence_report(str(out))
+    html = out.read_text()
+    assert f'download="{mintest_derip.consensus.id}.fasta"' in html
+    assert 'data-fasta="__derip__">View deRIP FASTA</button>' in html
+    # No CDS multi-FASTA download when there is no annotation.
+    assert 'deRIP_cds.fasta' not in html
+
+
 def test_report_total_rip_events(mintest_derip, tmp_path):
     """The RIP-events card shows a total equal to forward + reverse."""
     out = tmp_path / 'per_seq.html'

--- a/tests/test_persequence_report.py
+++ b/tests/test_persequence_report.py
@@ -506,6 +506,47 @@ def test_overview_download_without_gff(mintest_derip, tmp_path):
     assert 'deRIP_cds.fasta' not in html
 
 
+def test_overview_stats_table(mintest_derip, tmp_path):
+    """The overview carries a sortable all-sequence stats table + consensus row.
+
+    Rows: every input sequence plus a final deRIP-consensus row whose RIP-event
+    and RSI columns are not applicable (en-dash) while GC/CRI are computed. The
+    grouped headers mirror the per-sequence stat sections and every column is
+    click-to-sort.
+    """
+    from derip2.persequence_report import _STAT_SECTIONS, _overview_stats_table_html
+
+    out = tmp_path / 'per_seq.html'
+    mintest_derip.write_per_sequence_report(str(out))
+    html = out.read_text()
+
+    # The sortable table exists with grouped headers and a sort handler.
+    assert 'table class="psr-stats"' in html
+    for title, _desc, _cols in _STAT_SECTIONS:
+        assert f'>{title}<' in html
+    assert 'th.sortable' in html  # the JS sort wiring
+
+    # Build the table directly to assert on its structure.
+    df = mintest_derip.summarize_stats()
+    table = _overview_stats_table_html(df, mintest_derip)
+    body = re.search(r'<tbody>(.*)</tbody>', table, re.S).group(1)
+    rows = re.findall(r'<tr[^>]*>', body)
+    # One row per sequence plus the consensus row.
+    assert len(rows) == len(df) + 1
+    assert 'class="consensus-row"' in table
+
+    # Sortable column count = leading Sequence column + every flat stat column.
+    n_stats = sum(len(cols) for _t, _d, cols in _STAT_SECTIONS)
+    assert table.count('th class="sortable"') == n_stats + 1
+
+    # The consensus row: RIP/RSI columns are en-dashes; GC/CRI are numbers.
+    consensus = re.search(r'<tr class="consensus-row">(.*?)</tr>', table, re.S).group(1)
+    assert mintest_derip.consensus.id in consensus
+    assert '&ndash;' in consensus  # not-applicable RIP/RSI cells
+    cri, _pi, _si = mintest_derip.calculate_cri(mintest_derip.get_consensus_string())
+    assert f'{cri:.3f}' in consensus
+
+
 def test_report_total_rip_events(mintest_derip, tmp_path):
     """The RIP-events card shows a total equal to forward + reverse."""
     out = tmp_path / 'per_seq.html'

--- a/tests/test_persequence_report.py
+++ b/tests/test_persequence_report.py
@@ -537,7 +537,7 @@ def test_overview_stats_table(mintest_derip, tmp_path):
 
     # Sortable column count = leading Sequence column + every flat stat column.
     n_stats = sum(len(cols) for _t, _d, cols in _STAT_SECTIONS)
-    assert table.count('th class="sortable"') == n_stats + 1
+    assert table.count('class="sortable') == n_stats + 1
 
     # The consensus row: RIP/RSI columns are en-dashes; GC/CRI are numbers.
     consensus = re.search(r'<tr class="consensus-row">(.*?)</tr>', table, re.S).group(1)
@@ -545,6 +545,60 @@ def test_overview_stats_table(mintest_derip, tmp_path):
     assert '&ndash;' in consensus  # not-applicable RIP/RSI cells
     cri, _pi, _si = mintest_derip.calculate_cri(mintest_derip.get_consensus_string())
     assert f'{cri:.3f}' in consensus
+
+
+def test_overview_stats_table_green_flags(mintest_derip):
+    """CRI > 1 and a significant p-value are flagged green in the overview table."""
+    from derip2.persequence_report import _overview_stats_table_html
+
+    df = mintest_derip.summarize_stats().copy()
+    df.loc[df.index[0], 'CRI'] = 1.5  # > 1 -> green
+    df.loc[df.index[0], 'pvalue'] = 0.01  # < 0.05 -> green
+    df.loc[df.index[1], 'CRI'] = 0.5  # <= 1 -> not green
+    df.loc[df.index[1], 'pvalue'] = 0.5  # >= 0.05 -> not green
+    table = _overview_stats_table_html(df, mintest_derip)
+    rows = re.findall(r'<tr[^>]*>.*?</tr>', table, re.S)
+    # rows[0] header spans two <tr>; the first data row is the sequence at df row 0.
+    body_rows = [r for r in rows if 'scope="row"' in r]
+    r0, r1 = body_rows[0], body_rows[1]
+    assert 'class="value pos">1.500' in r0  # CRI 1.5 green (plain, no sign)
+    assert 'class="value pos">0.01' in r0  # pvalue 0.01 green
+    assert 'value pos">0.500' not in r1  # CRI 0.5 not green
+    assert 'value pos">0.5<' not in r1  # pvalue 0.5 not green
+
+
+def test_overview_stats_table_links_and_truncation(mintest_derip):
+    """Sequence names link to their page; sequences without a page stay unlinked."""
+    from derip2.persequence_report import _overview_stats_table_html
+
+    df = mintest_derip.summarize_stats()
+    # Simulate --max-report-seqs dropping rows: only rows 0 and 2 have panels.
+    table = _overview_stats_table_html(df, mintest_derip, row_to_panel={0: 1, 2: 2})
+    body = re.search(r'<tbody>(.*)</tbody>', table, re.S).group(1)
+    # Exactly two linked names, pointing at panels 1 and 2.
+    assert re.findall(r'data-goto="(\d+)"', body) == ['1', '2']
+    # The consensus row and dropped sequences carry no link.
+    consensus = re.search(r'<tr class="consensus-row">(.*?)</tr>', body, re.S).group(1)
+    assert 'seq-link' not in consensus
+
+
+def test_overview_aggregate_spectrum(mintest_derip, tmp_path):
+    """The overview page embeds a pooled SBS-96 spectrum (all seqs vs deRIP)."""
+    out = tmp_path / 'per_seq.html'
+    mintest_derip.write_per_sequence_report(str(out))
+    html = out.read_text()
+    assert 'Mutation spectrum' in html
+    # The pooled spectrum figure is embedded with its own unique id prefix.
+    assert 'ovwsbs-' in html
+
+
+def test_overview_initial_fit_and_goto_js(mintest_derip, tmp_path):
+    """The overview JS fits the MSA figure on load and wires sequence-name jumps."""
+    out = tmp_path / 'per_seq.html'
+    mintest_derip.write_per_sequence_report(str(out))
+    html = out.read_text()
+    assert 'function fitOverview' in html
+    assert "closest('[data-goto]')" in html
 
 
 def test_report_total_rip_events(mintest_derip, tmp_path):
@@ -568,9 +622,9 @@ def test_report_has_legend_and_zoom(mintest_derip, tmp_path):
     assert 'zoom-in' in html and 'zoom-out' in html and 'applyZoom' in html
 
 
-def test_report_pvalue_bold_when_significant(mintest_path):
-    """A strand-asymmetry p-value below 0.05 gets the bold .sig class."""
-    from derip2.persequence_report import _stats_sections_html
+def test_report_pvalue_green_when_significant(mintest_path):
+    """A strand-asymmetry p-value below 0.05 gets the .sig class (styled green)."""
+    from derip2.persequence_report import _PSR_STYLE, _stats_sections_html
 
     derip = DeRIP(mintest_path)
     derip.calculate_rip()
@@ -579,6 +633,9 @@ def test_report_pvalue_bold_when_significant(mintest_path):
     assert 'sig">' in _stats_sections_html(row)
     row['pvalue'] = 0.5
     assert 'sig">' not in _stats_sections_html(row)
+    # The .sig class is coloured green, not bold.
+    assert '.stat-card td.value.sig { color: #007a3d; }' in _PSR_STYLE
+    assert '.stat-card td.value.sig { font-weight: 700; }' not in _PSR_STYLE
 
 
 def test_report_cri_highlighted_when_above_one(mintest_path, tmp_path):


### PR DESCRIPTION
## Summary

Refines the `--plot` MSA visualization and substantially extends the per-sequence HTML report (`--per-seq-report`). Eight incremental commits, each with tests + docs.

### `fix:` MSA plot blur
- New `--plot-format svg|png` (default `svg`). The SVG migration in #42 embeds the dense per-cell base grid of wide (>500 col) alignments as a raster that blurs at high zoom; `png` writes a fully-rasterised, high-resolution image that stays sharp at any zoom.

### Per-sequence report — overview page
- **Annotation track** moved below the deRIP consensus (within the consensus section) it annotates.
- **FASTA downloads** (self-contained `data:` URIs) for the deRIP'd sequence and, with `--gff`, a CDS nucleotide multi-FASTA.
- **Click-to-view FASTA popups** on the deRIP row / CDS annotations, with Nucleotide + Translation tabs (genetic-code noted) and copy-to-clipboard.
- **Pooled SBS-96 mutation spectrum** across all sequences vs the reference.
- **Sortable all-sequence stats table** (grouped like the per-sequence cards) with a deRIP-consensus row (GC/CRI filled; RIP/RSI as `—`), sticky header rows + sticky sequence-name column, and sequence names linking to their pages.
- **Fit-to-width** initial zoom so the whole alignment is visible on load.

### Per-sequence report — style + UX
- CDS tooltips now show the CDS `ID` (not the parent transcript), so isoforms stay distinguishable.
- CRI > 1 and significant p-values (< 0.05) flagged green; per-sequence significant p-value is green rather than bold.
- **Progress reporting** — the previously-silent report generation now logs each expensive stage and shows a tqdm bar over the per-panel loop.

### Feature: alternative spectra reference
- `--spectra-ref-index N` compares each sequence's mutation spectra against a chosen alignment row (0-based; negatives allowed) instead of the deRIP consensus. The chosen reference gets an empty self-comparison spectrum; the report prose names it. Out-of-range values are rejected cleanly (library `ValueError` / CLI `BadParameter`).

## Testing
- Full suite passes (**412 tests**); `mkdocs build --strict` clean.
- Verified end-to-end: both plot formats (PNG magic bytes), the reordered track, CDS-ID tooltips, FASTA payloads (incl. minus-strand reverse-complement), clickable consensus surviving wide-alignment rasterisation, stats table + consensus row, and the alternative spectra reference (default/custom/negative/out-of-range).

## Notes / open questions
- Interactive report behaviours (modal, sort, sticky scroll, fit-on-load, name-link jumps) were validated structurally via tests but not driven live — the Chrome extension was unavailable during development.
- `--spectra-ref-index` is **0-based** (matches the MSA row index) even though report panels are labelled "Sequence 1/N". Happy to switch to 1-based or accept a sequence **name** if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvnYTjqPsTqq94uDCwGuJj