### PR TITLE
ci: measure coverage only on the Python 3.14 job

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,5 +26,8 @@ jobs:
         uses: CodSpeedHQ/action@v5
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
+          # addopts is cleared to drop the default --ignore=tests/benchmarks,
+          # which would otherwise deselect the path passed here. No coverage
+          # flags are involved: coverage is not part of the default addopts.
           run: uv run pytest tests/benchmarks --codspeed -o addopts=""
           mode: simulation

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,13 +27,19 @@ jobs:
           pip install '.[test]'  # Install all dependencies, including test-specific ones
       # Run pytest on the specified directory
       - name: Test with pytest
+        if: matrix.python-version != '3.14'
+        run: |
+          pytest
+      # Only the latest Python version measures coverage
+      - name: Test with pytest and coverage
+        if: matrix.python-version == '3.14'
         run: |
           pytest --cov=derip2 --cov-branch --cov-report=xml
       # Upload coverage report to Codecov
       # Only upload coverage for the latest Python version
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Adamtaranto/deRIP2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,10 @@ test = ["pytest", "pytest-codspeed", "pytest-cov"]
 [tool.pytest.ini_options]
 # Benchmarks are heavy and only meaningful under CodSpeed; exclude them from the
 # normal test run. Run them explicitly with: pytest tests/benchmarks --codspeed
-addopts = "-v --cov=derip2 --cov-branch --cov-report=xml --cov-report=term --ignore=tests/benchmarks"
+# Coverage is not enabled by default: CI measures it on one Python version only,
+# and coverage tracing would skew the CodSpeed benchmark timings. For a local
+# report run: pytest --cov=derip2 --cov-report=term
+addopts = "-v --ignore=tests/benchmarks"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 


### PR DESCRIPTION
## Why

Coverage flags (`--cov=derip2 --cov-branch --cov-report=xml --cov-report=term`) lived in the global pytest `addopts` in `pyproject.toml`, so **every** pytest invocation paid for coverage tracing: all five matrix Python versions, plus any benchmark run that did not override `addopts`. Only one matrix leg's report is ever uploaded, and coverage tracing skews CodSpeed timings.

Separately, the Codecov upload step was gated on `matrix.python-version == '3.13'`, contradicting the "only upload coverage for the latest Python version" comment above it now that 3.14 is in the matrix.

## Changes

- `pyproject.toml`: `addopts` is now `-v --ignore=tests/benchmarks` — coverage is opt-in per invocation.
- `.github/workflows/pytest.yml`: plain `pytest` for 3.10–3.13; `pytest --cov=derip2 --cov-branch --cov-report=xml` for 3.14 only. Codecov gate moved to `'3.14'`.
- `.github/workflows/codspeed.yml`: no behaviour change — the run now picks up no coverage flags by construction. Added a comment noting `-o addopts=""` is there to drop `--ignore=tests/benchmarks` (which would otherwise deselect the explicitly-passed path), not for coverage.

Note for local dev: a bare `pytest` no longer prints a coverage report. Run `pytest --cov=derip2 --cov-report=term` when you want one.

## Verification (local, py3.14)

- `pytest -q` → 529 passed, no coverage table, no `coverage.xml` written.
- `pytest tests/test_matrix_io.py --cov=derip2 --cov-branch --cov-report=xml` → passes, writes `coverage.xml`.
- `pytest tests/benchmarks --codspeed -o addopts="" --collect-only` → 17 tests collected.

CI on this PR should show the coverage step and Codecov upload on the 3.14 leg only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBP73GDKv5AFPKR5y1jmWq